### PR TITLE
Cache - return value fixed

### DIFF
--- a/src/Caching/Cache.php
+++ b/src/Caching/Cache.php
@@ -221,7 +221,7 @@ class Cache extends Nette\Object implements \ArrayAccess
 	 * Caches results of function/method calls.
 	 * @param  mixed
 	 * @param  array  dependencies
-	 * @return Closure
+	 * @return \Closure
 	 */
 	public function wrap($function, array $dependencies = NULL)
 	{


### PR DESCRIPTION
Also, many methods have such docs:

``` php
 * param  array  dependencies
```

I think correct is:

``` php
 * param  array  $dependencies
```

Shall I send PR?
