### PR TITLE
Bugfix: 00 char is killing C-based PHP modules

### DIFF
--- a/src/Caching/Cache.php
+++ b/src/Caching/Cache.php
@@ -34,7 +34,7 @@ class Cache extends Nette\Object implements \ArrayAccess
 		ALL = 'all';
 
 	/** @internal */
-	const NAMESPACE_SEPARATOR = "\x00";
+	const NAMESPACE_SEPARATOR = "\x01";
 
 	/** @var IStorage */
 	private $storage;


### PR DESCRIPTION
There is a problem with \x00 character in PHP modules written in C. C language uses \x00 char to mark the end of string.
Having \x00 as the default namespace separator (meaning it appears in the middle of the string) tends to break some of the commonly used libraries, such as php5-memcached and phpredis.
Solution we propose is a rather simple one - use \x01 instead of \x00 as a namespace separator.
