### PR TITLE
Control characters are not allowed in memcache keys (BC break)

### DIFF
--- a/src/Caching/Storages/MemcachedStorage.php
+++ b/src/Caching/Storages/MemcachedStorage.php
@@ -83,7 +83,7 @@ class MemcachedStorage extends Nette\Object implements Nette\Caching\IStorage
 	 */
 	public function read($key)
 	{
-		$key = $this->prefix . $key;
+		$key = $this->prepareKey($key);
 		$meta = $this->memcache->get($key);
 		if (!$meta) {
 			return NULL;
@@ -133,7 +133,7 @@ class MemcachedStorage extends Nette\Object implements Nette\Caching\IStorage
 			throw new Nette\NotSupportedException('Dependent items are not supported by MemcachedStorage.');
 		}
 
-		$key = $this->prefix . $key;
+		$key = $this->prepareKey($key);
 		$meta = array(
 			self::META_DATA => $data,
 		);
@@ -168,7 +168,8 @@ class MemcachedStorage extends Nette\Object implements Nette\Caching\IStorage
 	 */
 	public function remove($key)
 	{
-		$this->memcache->delete($this->prefix . $key, 0);
+		$key = $this->prepareKey($key);
+		$this->memcache->delete($key, 0);
 	}
 
 
@@ -188,5 +189,21 @@ class MemcachedStorage extends Nette\Object implements Nette\Caching\IStorage
 			}
 		}
 	}
+
+
+	/**
+	 * Prepare generic key for storing in memcache
+	 *
+	 * Control characters and whitespaces are forbidden in a valid memcache key.
+	 *
+	 * @param string $key
+	 * @see https://github.com/memcached/memcached/blob/master/doc/protocol.txt#L41
+	 * @return string
+	 */
+	protected function prepareKey($key)
+	{
+		return urlencode($this->prefix . $key);
+	}
+
 
 }


### PR DESCRIPTION
It is currently possible to use any character as a part of memcache key. According to memcache specification https://github.com/memcached/memcached/blob/master/doc/protocol.txt#L48 "the key must not include control characters or whitespace.". This causes problems even in the vanilla installation, as Cache class is using `\x00` as a default namespace separator.
The issue of disallowed characters is already tackled by FileStorage which deals with it by urlencoding the $key before using it. My solution is pretty much the same, I urlencode the $key before using it.
This solution may cause BC break in custom MemcacheStorage child implementations (that extend from MemcacheStorage).
