### PR TITLE
[WIP] ApcuStorage: user cache from APC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ script:
     - vendor/bin/tester tests -s -c tests/php-unix.ini
     - php code-checker/src/code-checker.php
 
+install:
+    - echo -e "yes\nno" | pecl install apcu-beta
+
 after_failure:
     # Print *.actual content
     - for i in $(find tests -name \*.actual); do echo "--- $i"; cat $i; echo; echo; done

--- a/src/Caching/Storages/ApcuStorage.php
+++ b/src/Caching/Storages/ApcuStorage.php
@@ -1,0 +1,167 @@
+<?php
+
+/**
+ * This file is part of the Nette Framework (http://nette.org)
+ * Copyright (c) 2004 David Grudl (http://davidgrudl.com)
+ */
+
+namespace Nette\Caching\Storages;
+
+use Nette,
+	Nette\Caching\Cache;
+
+
+/**
+ * APCu storage.
+ * @author     Filip Procházka
+ */
+class ApcuStorage extends Nette\Object implements Nette\Caching\IStorage
+{
+	/** @internal cache structure */
+	const META_CALLBACKS = Cache::CALLBACKS,
+		META_DATA = 'data',
+		META_DELTA = 'delta';
+
+	/** @var string */
+	private $prefix;
+
+	/** @var IJournal */
+	private $journal;
+
+
+	/**
+	 * Checks if APCu extension is available.
+	 * @return bool
+	 */
+	public static function isAvailable()
+	{
+		return (extension_loaded('apc') || extension_loaded('apcu')) && ini_get('apc.enabled');
+	}
+
+
+	public function __construct($prefix = '', IJournal $journal = NULL)
+	{
+		if (!static::isAvailable()) {
+			throw new Nette\NotSupportedException("PHP extension 'apcu' is not loaded.");
+		}
+
+		$this->prefix = $prefix;
+		$this->journal = $journal;
+	}
+
+
+	/**
+	 * Read from cache.
+	 * @param  string key
+	 * @return mixed|NULL
+	 */
+	public function read($key)
+	{
+		$key = $this->prefix . $key;
+		$meta = apc_fetch($key, $success);
+		if (!$success || !$meta) {
+			return NULL;
+		}
+
+		// meta structure:
+		// array(
+		//     data => stored data
+		//     delta => relative (sliding) expiration
+		//     callbacks => array of callbacks (function, args)
+		// )
+
+		// verify dependencies
+		if (!empty($meta[self::META_CALLBACKS]) && !Cache::checkCallbacks($meta[self::META_CALLBACKS])) {
+			apc_delete($key);
+			return NULL;
+		}
+
+		if (!empty($meta[self::META_DELTA])) {
+			apc_store($key, $meta, $meta[self::META_DELTA]);
+		}
+
+		return $meta[self::META_DATA];
+	}
+
+
+	/**
+	 * Prevents item reading and writing. Lock is released by write() or remove().
+	 * @param  string key
+	 * @return void
+	 */
+	public function lock($key)
+	{
+	}
+
+
+	/**
+	 * Writes item into the cache.
+	 * @param  string key
+	 * @param  mixed  data
+	 * @param  array  dependencies
+	 * @return void
+	 */
+	public function write($key, $data, array $dp)
+	{
+		if (isset($dp[Cache::ITEMS])) {
+			throw new Nette\NotSupportedException('Dependent items are not supported by ApcuStorage.');
+		}
+
+		$key = $this->prefix . $key;
+		$meta = array(
+			self::META_DATA => $data,
+		);
+
+		$expire = 0;
+		if (isset($dp[Cache::EXPIRATION])) {
+			$expire = (int) $dp[Cache::EXPIRATION];
+			if (!empty($dp[Cache::SLIDING])) {
+				$meta[self::META_DELTA] = $expire; // sliding time
+			}
+		}
+
+		if (isset($dp[Cache::CALLBACKS])) {
+			$meta[self::META_CALLBACKS] = $dp[Cache::CALLBACKS];
+		}
+
+		if (isset($dp[Cache::TAGS]) || isset($dp[Cache::PRIORITY])) {
+			if (!$this->journal) {
+				throw new Nette\InvalidStateException('CacheJournal has not been provided.');
+			}
+			$this->journal->write($key, $dp);
+		}
+
+		apc_store($key, $meta, $expire);
+	}
+
+
+	/**
+	 * Removes item from the cache.
+	 * @param  string key
+	 * @return void
+	 */
+	public function remove($key)
+	{
+		apc_delete($this->prefix . $key);
+	}
+
+
+	/**
+	 * Removes items from the cache by conditions & garbage collector.
+	 * @param  array  conditions
+	 * @return void
+	 */
+	public function clean(array $conditions)
+	{
+		if (!empty($conditions[Cache::ALL])) {
+			apc_clear_cache();
+			apc_clear_cache('user');
+
+		} elseif ($this->journal) {
+			foreach ($this->journal->clean($conditions) as $entry) {
+				apc_delete($entry);
+			}
+		}
+	}
+
+}

--- a/tests/Caching/Apcu.expiration.phpt
+++ b/tests/Caching/Apcu.expiration.phpt
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Test: Nette\Caching\Storages\ApcuStorage expiration test.
+ */
+
+use Nette\Caching\Storages\ApcuStorage,
+	Nette\Caching\Cache,
+	Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+if (!ApcuStorage::isAvailable()) {
+	Tester\Environment::skip('Requires PHP extension Apcu.');
+}
+
+
+$key = 'nette-expiration-key';
+$value = 'rulez';
+
+$cache = new Cache(new ApcuStorage());
+
+// Writing cache...
+$cache->save($key, $value, array(
+	Cache::EXPIRATION => time() + 3,
+));
+
+
+// Sleeping 1 second
+sleep(1);
+Assert::true( isset($cache[$key]) );
+
+
+// Sleeping 3 seconds
+sleep(3);
+Assert::false( isset($cache[$key]) );

--- a/tests/Caching/Apcu.files.phpt
+++ b/tests/Caching/Apcu.files.phpt
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Test: Nette\Caching\Storages\ApcuStorage files dependency test.
+ */
+
+use Nette\Caching\Storages\ApcuStorage,
+	Nette\Caching\Cache,
+	Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+if (!ApcuStorage::isAvailable()) {
+	Tester\Environment::skip('Requires PHP extension Apcu.');
+}
+
+
+$key = 'nette-files-key';
+$value = 'rulez';
+
+$cache = new Cache(new ApcuStorage());
+
+
+$dependentFile = TEMP_DIR . '/spec.file';
+@unlink($dependentFile);
+
+// Writing cache...
+$cache->save($key, $value, array(
+	Cache::FILES => array(
+		__FILE__,
+		$dependentFile,
+	),
+));
+
+Assert::true( isset($cache[$key]) );
+
+
+// Modifing dependent file
+file_put_contents($dependentFile, 'a');
+
+Assert::false( isset($cache[$key]) );
+
+
+// Writing cache...
+$cache->save($key, $value, array(
+	Cache::FILES => $dependentFile,
+));
+
+Assert::true( isset($cache[$key]) );
+
+
+// Modifing dependent file
+sleep(2);
+file_put_contents($dependentFile, 'b');
+clearstatcache();
+
+Assert::false( isset($cache[$key]) );

--- a/tests/Caching/Apcu.priority.phpt
+++ b/tests/Caching/Apcu.priority.phpt
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Test: Nette\Caching\Storages\ApcuStorage priority test.
+ */
+
+use Nette\Caching\Storages\ApcuStorage,
+	Nette\Caching\Storages\FileJournal,
+	Nette\Caching\Cache,
+	Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+if (!ApcuStorage::isAvailable()) {
+	Tester\Environment::skip('Requires PHP extension Apcu.');
+}
+
+
+$storage = new ApcuStorage('', new FileJournal(TEMP_DIR));
+$cache = new Cache($storage);
+
+
+// Writing cache...
+$cache->save('nette-priority-key1', 'value1', array(
+	Cache::PRIORITY => 100,
+));
+
+$cache->save('nette-priority-key2', 'value2', array(
+	Cache::PRIORITY => 200,
+));
+
+$cache->save('nette-priority-key3', 'value3', array(
+	Cache::PRIORITY => 300,
+));
+
+$cache['nette-priority-key4'] = 'value4';
+
+
+// Cleaning by priority...
+$cache->clean(array(
+	Cache::PRIORITY => '200',
+));
+
+Assert::false( isset($cache['nette-priority-key1']) );
+Assert::false( isset($cache['nette-priority-key2']) );
+Assert::true( isset($cache['nette-priority-key3']) );
+Assert::true( isset($cache['nette-priority-key4']) );

--- a/tests/Caching/Apcu.sliding.phpt
+++ b/tests/Caching/Apcu.sliding.phpt
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * Test: Nette\Caching\Storages\ApcuStorage sliding expiration test.
+ */
+
+use Nette\Caching\Storages\ApcuStorage,
+	Nette\Caching\Cache,
+	Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+if (!ApcuStorage::isAvailable()) {
+	Tester\Environment::skip('Requires PHP extension Apcu.');
+}
+
+
+$key = 'nette-sliding-key';
+$value = 'rulez';
+
+$cache = new Cache(new ApcuStorage());
+
+
+// Writing cache...
+$cache->save($key, $value, array(
+	Cache::EXPIRATION => time() + 3,
+	Cache::SLIDING => TRUE,
+));
+
+
+for ($i = 0; $i < 5; $i++) {
+	// Sleeping 1 second
+	sleep(1);
+
+	Assert::true( isset($cache[$key]) );
+
+}
+
+// Sleeping few seconds...
+sleep(5);
+
+Assert::false( isset($cache[$key]) );

--- a/tests/Caching/Apcu.tags.phpt
+++ b/tests/Caching/Apcu.tags.phpt
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Test: Nette\Caching\Storages\ApcuStorage tags dependency test.
+ */
+
+use Nette\Caching\Storages\ApcuStorage,
+	Nette\Caching\Storages\FileJournal,
+	Nette\Caching\Cache,
+	Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+if (!ApcuStorage::isAvailable()) {
+	Tester\Environment::skip('Requires PHP extension Apcu.');
+}
+
+
+$storage = new ApcuStorage('', new FileJournal(TEMP_DIR));
+$cache = new Cache($storage);
+
+
+// Writing cache...
+$cache->save('nette-tags-key1', 'value1', array(
+	Cache::TAGS => array('one', 'two'),
+));
+
+$cache->save('nette-tags-key2', 'value2', array(
+	Cache::TAGS => array('one', 'three'),
+));
+
+$cache->save('nette-tags-key3', 'value3', array(
+	Cache::TAGS => array('two', 'three'),
+));
+
+$cache['nette-tags-key4'] = 'value4';
+
+
+// Cleaning by tags...
+$cache->clean(array(
+	Cache::TAGS => 'one',
+));
+
+Assert::false( isset($cache['nette-tags-key1']) );
+Assert::false( isset($cache['nette-tags-key2']) );
+Assert::true( isset($cache['nette-tags-key3']) );
+Assert::true( isset($cache['nette-tags-key4']) );

--- a/tests/php-unix.ini
+++ b/tests/php-unix.ini
@@ -1,6 +1,7 @@
 [PHP]
 ;extension_dir = "./ext"
 extension=memcache.so
+extension=apcu.so
 
 [Zend]
 ;zend_extension="./ext/zend_extension"


### PR DESCRIPTION
APC opcode caching might be dead, because the zend optimizer plus is now native for 5.5+,
but [the APCu is still alive and thriving](http://pecl.php.net/package/apcu). And I think It's pretty good storage option for some types of cache. Therefore I propose adding new storage supporting it.

I've copied the tests from memcached and rewritten them for the new storage.

---

There is a problem - Apcu clears cache depending on TTL only [when new request occurs](http://php.net/manual/en/function.apc-store.php) - which means It cannot be easily tested. Any idea how to test it?

Or should I implement "fallback" expiration check that will store when the key should be expired and then expire it manually if neccesary?
