### PR TITLE
Feature request: CacheMacro::createCache(): support for defining dependency as a fallback

### DIFF
--- a/src/Bridges/CacheLatte/CacheMacro.php
+++ b/src/Bridges/CacheLatte/CacheMacro.php
@@ -105,6 +105,10 @@ class CacheMacro extends Nette\Object implements Latte\IMacro
 
 		$cache = new Nette\Caching\Cache($cacheStorage, 'Nette.Templating.Cache');
 		if ($helper = $cache->start($key)) {
+			if(isset($args['dependencies']) && is_callable($args['dependencies'])) {
+				$dependenciesFallback = $args['dependencies'];
+				$args = $dependenciesFallback();
+			}
 			if (isset($args['expire'])) {
 				$args['expiration'] = $args['expire']; // back compatibility
 			}

--- a/tests/Caching.Latte/CacheMacro.createCache.phpt
+++ b/tests/Caching.Latte/CacheMacro.createCache.phpt
@@ -16,7 +16,17 @@ test(function() {
 	$parents = array();
 	$dp = array(Cache::TAGS => array('rum', 'cola'));
 	$outputHelper = CacheMacro::createCache(new DevNullStorage(), 'test', $parents, $dp);
-
 	Assert::type('\Nette\Caching\OutputHelper', $outputHelper);
+	Assert::same($dp + array('expire' => '+ 7 days'), $outputHelper->dependencies);
+});
+
+test(function() {
+	$parents = array();
+	$dp = array(Cache::TAGS => array('rum', 'cola'));
+	//time consuming operation
+	$dpFallback = function() use ($dp) {
+		return $dp;
+	};
+	$outputHelper = CacheMacro::createCache(new DevNullStorage(), 'test', $parents, array('dependencies' => $dpFallback));
 	Assert::same($dp + array('expire' => '+ 7 days'), $outputHelper->dependencies);
 });

--- a/tests/Caching.Latte/CacheMacro.createCache.phpt
+++ b/tests/Caching.Latte/CacheMacro.createCache.phpt
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Test: Nette\Bridges\CacheLatte\CacheMacro createCache()
+ */
+
+use Nette\Bridges\CacheLatte\CacheMacro,
+	Tester\Assert,
+	Nette\Caching\Storages\DevNullStorage,
+	Nette\Caching\Cache;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+test(function() {
+	$parents = array();
+	$dp = array(Cache::TAGS => array('rum', 'cola'));
+	$outputHelper = CacheMacro::createCache(new DevNullStorage(), 'test', $parents, $dp);
+
+	Assert::type('\Nette\Caching\OutputHelper', $outputHelper);
+	Assert::same($dp + array('expire' => '+ 7 days'), $outputHelper->dependencies);
+});


### PR DESCRIPTION
Today we find out that defining depencencies in cache is time consuming operation.
For example.:

```php
$this->template->articleExpiration = $this->articleFacade->getExpiration($id); //DB query
```
```latte
{cache "article/$id", ['expire' => $articleExpiration]}
```
Of course, we can cache expiration for every article.
But if 4th argument could be fallback, everything will be easier:

```php
$this->template->articleExpirationFallback = function() use ($id) {
    return ['expire' => $this->articleFacade->getExpiration($id)];
};
```
```latte
{cache "article/$id", $articleExpirationFallback}
```