### PR TITLE
SQLiteStorage: expiration and tweaks

### DIFF
--- a/src/Caching/Storages/SQLiteStorage.php
+++ b/src/Caching/Storages/SQLiteStorage.php
@@ -18,7 +18,7 @@ use Nette,
  */
 class SQLiteStorage extends Nette\Object implements Nette\Caching\IStorage
 {
-	/** @var PDO */
+	/** @var \PDO */
 	private $pdo;
 
 
@@ -29,7 +29,8 @@ class SQLiteStorage extends Nette\Object implements Nette\Caching\IStorage
 		$this->pdo->exec('
 			PRAGMA foreign_keys = ON;
 			CREATE TABLE IF NOT EXISTS cache (
-				key BLOB NOT NULL PRIMARY KEY, data BLOB NOT NULL
+				key BLOB NOT NULL PRIMARY KEY,
+				data BLOB NOT NULL
 			);
 			CREATE TABLE IF NOT EXISTS tags (
 				key BLOB NOT NULL REFERENCES cache ON DELETE CASCADE,
@@ -75,7 +76,7 @@ class SQLiteStorage extends Nette\Object implements Nette\Caching\IStorage
 	 */
 	public function write($key, $data, array $dependencies)
 	{
-		$this->pdo->prepare('BEGIN TRANSACTION');
+		$this->pdo->exec('BEGIN TRANSACTION');
 		$this->pdo->prepare('REPLACE INTO cache (key, data) VALUES (?, ?)')
 			->execute(array($key, serialize($data)));
 
@@ -87,7 +88,7 @@ class SQLiteStorage extends Nette\Object implements Nette\Caching\IStorage
 			$this->pdo->prepare('INSERT INTO tags (key, tag) SELECT ?, ?' . str_repeat('UNION SELECT ?, ?', count($arr) / 2 - 1))
 				->execute($arr);
 		}
-		$this->pdo->prepare('COMMIT');
+		$this->pdo->exec('COMMIT');
 	}
 
 

--- a/src/Caching/Storages/SQLiteStorage.php
+++ b/src/Caching/Storages/SQLiteStorage.php
@@ -41,6 +41,7 @@ class SQLiteStorage extends Nette\Object implements Nette\Caching\IStorage
 			CREATE INDEX IF NOT EXISTS cache_expire ON cache(expire);
 			CREATE INDEX IF NOT EXISTS tags_key ON tags(key);
 			CREATE INDEX IF NOT EXISTS tags_tag ON tags(tag);
+			PRAGMA synchronous = OFF;
 		');
 	}
 

--- a/tests/Caching/SQLiteStorage.basic.phpt
+++ b/tests/Caching/SQLiteStorage.basic.phpt
@@ -21,7 +21,7 @@ if (!extension_loaded('pdo_sqlite')) {
 $key = array(1, TRUE);
 $value = range("\x00", "\xFF");
 
-$cache = new Cache(new SQLiteStorage(TEMP_DIR . '/db.db3'));
+$cache = new Cache(new SQLiteStorage);
 
 Assert::null( $cache->load($key) );
 

--- a/tests/Caching/SQLiteStorage.expiration.phpt
+++ b/tests/Caching/SQLiteStorage.expiration.phpt
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * Test: Nette\Caching\Storages\SQLiteStorage expiration test.
+ */
+
+use Nette\Caching\Cache,
+	Nette\Caching\Storages\SQLiteStorage,
+	Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+if (!extension_loaded('pdo_sqlite')) {
+	Tester\Environment::skip('Requires PHP extension pdo_sqlite.');
+}
+
+
+$key = 'nette';
+$value = 'rulez';
+
+$cache = new Cache(new SQLiteStorage);
+
+
+// Writing cache...
+$cache->save($key, $value, array(
+	Cache::EXPIRATION => time() + 3,
+));
+
+
+// Sleeping 1 second
+sleep(1);
+clearstatcache();
+Assert::truthy( $cache->load($key) );
+
+
+// Sleeping 3 seconds
+sleep(3);
+clearstatcache();
+Assert::null( $cache->load($key) );

--- a/tests/Caching/SQLiteStorage.sliding.phpt
+++ b/tests/Caching/SQLiteStorage.sliding.phpt
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * Test: Nette\Caching\Storages\SQLiteStorage expiration test.
+ */
+
+use Nette\Caching\Cache,
+	Nette\Caching\Storages\SQLiteStorage,
+	Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+if (!extension_loaded('pdo_sqlite')) {
+	Tester\Environment::skip('Requires PHP extension pdo_sqlite.');
+}
+
+
+$key = 'nette';
+$value = 'rulez';
+
+$cache = new Cache(new SQLiteStorage);
+
+
+// Writing cache...
+$cache->save($key, $value, array(
+	Cache::EXPIRATION => time() + 3,
+	Cache::SLIDING => TRUE,
+));
+
+
+for ($i = 0; $i < 5; $i++) {
+	// Sleeping 1 second
+	sleep(1);
+
+	Assert::truthy( $cache->load($key) );
+}
+
+// Sleeping few seconds...
+sleep(5);
+
+Assert::null( $cache->load($key) );

--- a/tests/Caching/SQLiteStorage.tags.phpt
+++ b/tests/Caching/SQLiteStorage.tags.phpt
@@ -17,7 +17,7 @@ if (!extension_loaded('pdo_sqlite')) {
 }
 
 
-$cache = new Cache(new SQLiteStorage(TEMP_DIR . '/db.db3'));
+$cache = new Cache(new SQLiteStorage);
 
 
 // Writing cache...


### PR DESCRIPTION
Main purpose of this PR is the expiration implementation. Other commits can be removed if displeasured.

Note: Expiration and slide can be moved to own table, e.g. `meta`. Database file will be smaller and better normalized, but loading will be slower I guess (didn't measure it). Imho it's topic for PR with a tunning of performance.

Some measurements:
```
2000 keys with 1kB string value, database file on SSD

foreach(...) $cache->save();
foreach(...) $cache->load();
foreach(...) $cache->remove();

Before this PR
--------------
5.63819408[s]: Save
0.15597486[s]: Load
4.92538691[s]: Remove

Expire in cache table
---------------------
6.12778687[s]: Save
0.17317390[s]: Load
4.98942900[s]: Remove

Added slide (no value has sliding)
----------------------------------
5.76604009[s]: Save
0.18285584[s]: Load
5.60287094[s]: Remove

Added slide (every value has sliding)
-------------------------------------
5.77139378[s]: Save
5.48683000[s]: Load
5.53447104[s]: Remove
```

`PRAGMA synchronous = OFF` is potentionally dangerous ([doc](https://www.sqlite.org/pragma.html#pragma_synchronous)). It should be safe when closing DB connection, so per HTTP request. Has someone experiences with it in web environment?

Measured with the last case:
```
Added slide (every value has sliding) + synchronous = OFF
---------------------------------------------------------
1.71335387[s]: Save
1.58130002[s]: Load
1.46945906[s]: Remove
```
