### PR TITLE
SQLiteJournal: filesystem permissions like ordinary file

### DIFF
--- a/src/Caching/Storages/SQLiteJournal.php
+++ b/src/Caching/Storages/SQLiteJournal.php
@@ -37,6 +37,10 @@ class SQLiteJournal extends Nette\Object implements IJournal
 
 	private function open()
 	{
+		if ($this->path !== ':memory:' && !is_file($this->path)) {
+			touch($this->path); // ensures ordinary file permissions
+		}
+
 		$this->pdo = new \PDO('sqlite:' . $this->path);
 		$this->pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
 		$this->pdo->exec('

--- a/tests/Storages/SQLiteJournal.permissions.phpt
+++ b/tests/Storages/SQLiteJournal.permissions.phpt
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Test: Nette\Caching\Storages\SQLiteJournal database file permissions.
+ */
+
+use Nette\Caching\Storages\SQLiteJournal;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+if (!extension_loaded('pdo_sqlite')) {
+	Tester\Environment::skip('Requires PHP extension pdo_sqlite.');
+} elseif (defined('PHP_WINDOWS_VERSION_BUILD')) {
+	Tester\Environment::skip('UNIX test only.');
+}
+
+
+test(function () {
+	$file = TEMP_DIR . '/sqlitejournal.permissions.1.sqlite';
+	Assert::false(file_exists($file));
+
+	umask(0);
+	(new SQLiteJournal($file))->write('foo', []);
+
+	Assert::same(0666, fileperms($file) & 0777);
+});
+
+
+test(function () {
+	$file = TEMP_DIR . '/sqlitejournal.permissions.2.sqlite';
+	Assert::false(file_exists($file));
+
+	umask(0077);
+	(new SQLiteJournal($file))->write('foo', []);
+
+	Assert::same(0600, fileperms($file) & 0777);
+});


### PR DESCRIPTION
SQLiteJournal is used with the FileCache. Seems correct to me, it should behave in the same way as ordinary files.