### PR TITLE
SQLiteJournal: fixed priorities rewriting

### DIFF
--- a/src/Caching/Storages/SQLiteJournal.php
+++ b/src/Caching/Storages/SQLiteJournal.php
@@ -44,7 +44,7 @@ class SQLiteJournal extends Nette\Object implements IJournal
 			CREATE INDEX IF NOT EXISTS idx_tags_key ON tags(key);
 			CREATE INDEX IF NOT EXISTS idx_tags_tag ON tags(tag);
 			CREATE UNIQUE INDEX IF NOT EXISTS idx_tags_key_tag ON tags(key, tag);
-			CREATE INDEX IF NOT EXISTS idx_priorities_key ON priorities(key);
+			CREATE UNIQUE INDEX IF NOT EXISTS idx_priorities_key ON priorities(key);
 			CREATE INDEX IF NOT EXISTS idx_priorities_priority ON priorities(priority);
 		');
 	}

--- a/tests/Storages/IJournalTestCase.inc
+++ b/tests/Storages/IJournalTestCase.inc
@@ -4,7 +4,7 @@
  * Test: Common tests for all IJournal implementations.
  */
 
-use	Nette\Caching\Cache;
+use Nette\Caching\Cache;
 use Nette\Caching\Storages\IJournal;
 use Tester\Assert;
 
@@ -242,12 +242,15 @@ abstract class IJournalTestCase extends Tester\TestCase
 	final public function testDuplicatedDifferentPriorities()
 	{
 		$this->journal->write('ok_test_bb', [
-			Cache::PRIORITY => 15
+			Cache::PRIORITY => 10
 		]);
 
 		$this->journal->write('ok_test_bb', [
 			Cache::PRIORITY => 20
 		]);
+
+		Assert::same([
+		], $this->journal->clean([Cache::PRIORITY => 15]));
 
 		Assert::same([
 			'ok_test_bb',


### PR DESCRIPTION
SQLiteJournal: fixed priorities rewriting

REPLACE does not work without unique constaint.