### PR TITLE
added bulk read support

### DIFF
--- a/src/Caching/Cache.php
+++ b/src/Caching/Cache.php
@@ -105,17 +105,19 @@ class Cache
 	 */
 	public function bulkLoad(array $keys, $fallback = NULL)
 	{
+		if (count($keys) === 0) {
+			return [];
+		}
 		foreach ($keys as $key) {
 			if (!is_scalar($key)) {
 				throw new Nette\InvalidArgumentException('Only scalar keys are allowed in a bulkLoad method.');
 			}
 		}
 		$storageKeys = array_map([$this, 'generateKey'], $keys);
-		$storage = $this->getStorage();
-		if ($storage instanceof IBulkReadStorage) {
-			$cacheData = $storage->bulkRead($storageKeys);
+		if ($this->storage instanceof IBulkReadStorage) {
+			$cacheData = $this->storage->bulkRead($storageKeys);
 		} else {
-			$cacheData = array_combine($storageKeys, array_map([$storage, 'read'], $storageKeys));
+			$cacheData = array_combine($storageKeys, array_map([$this->storage, 'read'], $storageKeys));
 		}
 		$result = [];
 		foreach ($keys as $i => $key) {

--- a/src/Caching/Cache.php
+++ b/src/Caching/Cache.php
@@ -110,18 +110,16 @@ class Cache
 				throw new Nette\InvalidArgumentException('Only scalar keys are allowed in a bulkLoad method.');
 			}
 		}
-		$keys = array_combine(array_map([$this, 'generateKey'], $keys), $keys);
+		$storageKeys = array_map([$this, 'generateKey'], $keys);
 		$storage = $this->getStorage();
 		if ($storage instanceof IBulkReadStorage) {
-			$cacheData = $storage->bulkRead(array_keys($keys));
+			$cacheData = $storage->bulkRead($storageKeys);
 		} else {
-			$cacheData = [];
-			foreach ($keys as $storageKey => $key) {
-				$cacheData[$storageKey] = $this->load($key);
-			}
+			$cacheData = array_combine($storageKeys, array_map([$storage, 'read'], $storageKeys));
 		}
 		$result = [];
-		foreach ($keys as $storageKey => $key) {
+		foreach ($keys as $i => $key) {
+			$storageKey = $storageKeys[$i];
 			if (isset($cacheData[$storageKey])) {
 				$result[$key] = $cacheData[$storageKey];
 			} elseif ($fallback) {

--- a/src/Caching/IBulkReadStorage.php
+++ b/src/Caching/IBulkReadStorage.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * This file is part of the Nette Framework (https://nette.org)
+ * Copyright (c) 2004 David Grudl (https://davidgrudl.com)
+ */
+
+namespace Nette\Caching;
+
+
+/**
+ * Cache storage with a bulk read support.
+ */
+interface IBulkReadStorage extends IStorage
+{
+
+	/**
+	 * Read from cache.
+	 * @param  string key
+	 * @return array key => value pairs, missing items are omitted
+	 */
+	function bulkRead(array $keys);
+
+}

--- a/src/Caching/Storages/NewMemcachedStorage.php
+++ b/src/Caching/Storages/NewMemcachedStorage.php
@@ -88,6 +88,7 @@ class NewMemcachedStorage implements Nette\Caching\IBulkReadStorage
 		if (!$meta) {
 			return NULL;
 		}
+
 		// meta structure:
 		// array(
 		//     data => stored data
@@ -104,7 +105,6 @@ class NewMemcachedStorage implements Nette\Caching\IBulkReadStorage
 		if (!empty($meta[self::META_DELTA])) {
 			$this->memcached->replace($key, $meta, $meta[self::META_DELTA] + time());
 		}
-
 
 		return $meta[self::META_DATA];
 	}

--- a/src/Caching/Storages/NewMemcachedStorage.php
+++ b/src/Caching/Storages/NewMemcachedStorage.php
@@ -143,17 +143,6 @@ class NewMemcachedStorage implements Nette\Caching\IBulkReadStorage
 
 
 	/**
-	 * @param string
-	 * @param array
-	 * @return bool
-	 */
-	private function verifyMeta($key, $meta)
-	{
-
-	}
-
-
-	/**
 	 * Prevents item reading and writing. Lock is released by write() or remove().
 	 * @param  string key
 	 * @return void

--- a/tests/Caching/Cache.bulkLoad.phpt
+++ b/tests/Caching/Cache.bulkLoad.phpt
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * Test: Nette\Caching\Cache load().
+ */
+
+use Nette\Caching\Cache;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+require __DIR__ . '/Cache.php';
+
+//storage without bulk load support
+test(function () {
+	$storage = new TestStorage();
+	$cache = new Cache($storage, 'ns');
+	Assert::same([1 => NULL, 2 => NULL], $cache->bulkLoad([1, 2]), 'data');
+
+	Assert::same([1 => 1, 2 => 2], $cache->bulkLoad([1, 2], function ($key) {
+		return $key;
+	}));
+
+	$data = $cache->bulkLoad([1, 2]);
+	Assert::same(1, $data[1]['data']);
+	Assert::same(2, $data[2]['data']);
+});
+
+//storage with bulk load support
+test(function () {
+	$storage = new BulkReadTestStorage();
+	$cache = new Cache($storage, 'ns');
+	Assert::same([1 => NULL, 2 => NULL], $cache->bulkLoad([1, 2]));
+
+	Assert::same([1 => 1, 2 => 2], $cache->bulkLoad([1, 2], function ($key) {
+		return $key;
+	}));
+
+	$data = $cache->bulkLoad([1, 2]);
+	Assert::same(1, $data[1]['data']);
+	Assert::same(2, $data[2]['data']);
+});
+
+//dependencies
+test(function () {
+	$storage = new BulkReadTestStorage();
+	$cache = new Cache($storage, 'ns');
+	$dependencies = [Cache::TAGS => 'tag'];
+	$cache->bulkLoad([1], function ($key, & $deps) use ($dependencies) {
+		$deps = $dependencies;
+		return $key;
+	});
+
+	$data = $cache->bulkLoad([1, 2]);
+	Assert::same($dependencies, $data[1]['dependencies']);
+});
+
+test(function () {
+	Assert::exception(function () {
+		$cache = new Cache(new BulkReadTestStorage());
+		$cache->bulkLoad([[1]]);
+	}, Nette\InvalidArgumentException::class, 'Only scalar keys are allowed in a bulkLoad method.');
+});

--- a/tests/Caching/Cache.php
+++ b/tests/Caching/Cache.php
@@ -1,5 +1,6 @@
 <?php
 
+use Nette\Caching\IBulkReadStorage;
 use Nette\Caching\IStorage;
 
 class TestStorage implements IStorage
@@ -24,4 +25,21 @@ class TestStorage implements IStorage
 	public function remove($key) {}
 
 	public function clean(array $conditions) {}
+}
+
+class BulkReadTestStorage extends TestStorage implements IBulkReadStorage
+{
+	function bulkRead(array $keys)
+	{
+		$result = [];
+		foreach ($keys as $key) {
+			$data = $this->read($key);
+			if ($data !== NULL) {
+				$result[$key] = $data;
+			}
+		}
+
+		return $result;
+	}
+
 }

--- a/tests/Storages/NewMemcached.bulkRead.phpt
+++ b/tests/Storages/NewMemcached.bulkRead.phpt
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Test: Nette\Caching\Storages\NewMemcachedStorage and bulkRead
+ */
+
+use Nette\Caching\Storages\NewMemcachedStorage;
+use Nette\Caching\Cache;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+if (!NewMemcachedStorage::isAvailable()) {
+	Tester\Environment::skip('Requires PHP extension Memcached.');
+}
+
+Tester\Environment::lock('memcached-files', TEMP_DIR);
+
+
+
+$cache = new Cache(new NewMemcachedStorage('localhost'));
+
+$cache->save('foo', 'bar');
+
+Assert::same(['foo' => 'bar', 'lorem' => NULL], $cache->bulkLoad(['foo', 'lorem']));

--- a/tests/Storages/NewMemcached.sliding.phpt
+++ b/tests/Storages/NewMemcached.sliding.phpt
@@ -44,3 +44,26 @@ for ($i = 0; $i < 5; $i++) {
 sleep(5);
 
 Assert::null($cache->load($key));
+
+
+// Bulk
+
+// Writing cache...
+$cache->save($key, $value, [
+	Cache::EXPIRATION => time() + 3,
+	Cache::SLIDING => TRUE,
+]);
+
+
+for ($i = 0; $i < 5; $i++) {
+	// Sleeping 1 second
+	sleep(1);
+
+	Assert::truthy($cache->bulkLoad([$key])[$key]);
+
+}
+
+// Sleeping few seconds...
+sleep(5);
+
+Assert::null($cache->load([$key])[$key]);

--- a/tests/Storages/SQLiteStorage.bulkRead.phpt
+++ b/tests/Storages/SQLiteStorage.bulkRead.phpt
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Test: Nette\Caching\Storages\SQLiteStorage and bulk read.
+ */
+
+use Nette\Caching\Cache;
+use Nette\Caching\Storages\SQLiteStorage;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+if (!extension_loaded('pdo_sqlite')) {
+	Tester\Environment::skip('Requires PHP extension pdo_sqlite.');
+}
+
+
+$cache = new Cache(new SQLiteStorage(':memory:'));
+$cache->save('foo', 'bar');
+
+Assert::same(['foo' => 'bar', 'lorem' => NULL], $cache->bulkLoad(['foo', 'lorem']));

--- a/tests/Storages/SQLiteStorage.sliding.phpt
+++ b/tests/Storages/SQLiteStorage.sliding.phpt
@@ -41,3 +41,23 @@ for ($i = 0; $i < 5; $i++) {
 sleep(5);
 
 Assert::null($cache->load($key));
+
+
+// Writing cache...
+$cache->save($key, $value, [
+	Cache::EXPIRATION => time() + 3,
+	Cache::SLIDING => TRUE,
+]);
+
+
+for ($i = 0; $i < 5; $i++) {
+	// Sleeping 1 second
+	sleep(1);
+
+	Assert::truthy($cache->bulkLoad([$key])[$key]);
+}
+
+// Sleeping few seconds...
+sleep(5);
+
+Assert::null($cache->bulkLoad([$key])[$key]);


### PR DESCRIPTION
- [x] is fallback necessary ?
- [x] SQLiteStorage and NewMemcachedStorage: read methods internally use bulkRead. Is it ok? I think performance impact won't be serious.
- [ ] non-scalar keys are not allowed in a bulkLoad - alternative would be serialize non-scalar keys. what do you think?