### PR TITLE
SQLiteStorage: filesystem permissions like ordinary file

### DIFF
--- a/src/Caching/Storages/SQLiteStorage.php
+++ b/src/Caching/Storages/SQLiteStorage.php
@@ -24,6 +24,10 @@ class SQLiteStorage implements Nette\Caching\IStorage, Nette\Caching\IBulkReader
 
 	public function __construct($path)
 	{
+		if ($path !== ':memory:' && !is_file($path)) {
+			touch($path); // ensures ordinary file permissions
+		}
+
 		$this->pdo = new \PDO('sqlite:' . $path);
 		$this->pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
 		$this->pdo->exec('

--- a/tests/Storages/SQLiteStorage.permissions.phpt
+++ b/tests/Storages/SQLiteStorage.permissions.phpt
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Test: Nette\Caching\Storages\SQLiteStorage database file permissions.
+ */
+
+use Nette\Caching\Storages\SQLiteStorage;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+if (!extension_loaded('pdo_sqlite')) {
+	Tester\Environment::skip('Requires PHP extension pdo_sqlite.');
+} elseif (defined('PHP_WINDOWS_VERSION_BUILD')) {
+	Tester\Environment::skip('UNIX test only.');
+}
+
+
+test(function () {
+	$file = TEMP_DIR . '/sqlitestorage.permissions.1.sqlite';
+	Assert::false(file_exists($file));
+
+	umask(0);
+	(new SQLiteStorage($file))->write('foo', 'bar', []);
+
+	Assert::same(0666, fileperms($file) & 0777);
+});
+
+
+test(function () {
+	$file = TEMP_DIR . '/sqlitestorage.permissions.2.sqlite';
+	Assert::false(file_exists($file));
+
+	umask(0077);
+	(new SQLiteStorage($file))->write('foo', 'bar', []);
+
+	Assert::same(0600, fileperms($file) & 0777);
+});


### PR DESCRIPTION
This refers to #29 and #30 .

SQLiteJournal behaves differently than SQLiteStorage.

Shouldn't it be consistent?

Affected versions of nette/caching are v2.4 and v2.5.

Thanks.
