### PR TITLE
General error: 25 bind or column index out of range fix

### DIFF
--- a/src/Caching/Cache.php
+++ b/src/Caching/Cache.php
@@ -199,6 +199,11 @@ class Cache
 			$dp[self::EXPIRATION] = Nette\Utils\DateTime::from($dp[self::EXPIRATION])->format('U') - time();
 		}
 
+		// make array list from TAGS
+		if (isset($dp[self::TAGS])) {
+			$dp[self::TAGS] = array_values((array) $dp[self::TAGS]);
+		}
+
 		// convert FILES into CALLBACKS
 		if (isset($dp[self::FILES])) {
 			foreach (array_unique((array) $dp[self::FILES]) as $item) {
@@ -248,7 +253,11 @@ class Cache
 	 */
 	public function clean(array $conditions = NULL)
 	{
-		$this->storage->clean((array) $conditions);
+		$conditionItems = (array) $conditions;
+		if (isset($conditionItems[self::TAGS])) {
+			$conditionItems[self::TAGS] = array_values((array) $conditionItems[self::TAGS]);
+		}
+		$this->storage->clean($conditionItems);
 	}
 
 

--- a/tests/Storages/FileStorage.tags.phpt
+++ b/tests/Storages/FileStorage.tags.phpt
@@ -27,18 +27,43 @@ $cache->save('key2', 'value2', [
 ]);
 
 $cache->save('key3', 'value3', [
+	Cache::TAGS => ['foo' => 'one', 'bar' => 'two'],
+]);
+
+$cache->save('key4', 'value4', [
+	Cache::TAGS => 'one',
+]);
+
+$cache->save('key5', 'value5', [
 	Cache::TAGS => ['two', 'three'],
 ]);
 
-$cache->save('key4', 'value4');
+$cache->save('key6', 'value6', [
+	Cache::TAGS => ['foo' => 'two', 'bar' => 'three'],
+]);
+
+$cache->save('key7', 'value7', [
+	Cache::TAGS => 'two',
+]);
+
+$cache->save('key8', 'value8');
 
 
 // Cleaning by tags...
 $cache->clean([
-	Cache::TAGS => 'one',
+	Cache::TAGS => [
+		0 => 'non-existent1',
+		1 => 'non-existent2',
+		3 => 'one',
+		5 => 'non-existent3'
+	]
 ]);
 
 Assert::null($cache->load('key1'));
 Assert::null($cache->load('key2'));
-Assert::truthy($cache->load('key3'));
-Assert::truthy($cache->load('key4'));
+Assert::null($cache->load('key3'));
+Assert::null($cache->load('key4'));
+Assert::truthy($cache->load('key5'));
+Assert::truthy($cache->load('key6'));
+Assert::truthy($cache->load('key7'));
+Assert::truthy($cache->load('key8'));


### PR DESCRIPTION
When called SQLiteJournal::clean method with non-consequent integer keys, method execute had thrown exception General error: 25 bind or column index out of range.