### PR TITLE
Cache: create dependencies when closing macro

### DIFF
--- a/src/Bridges/CacheLatte/CacheMacro.php
+++ b/src/Bridges/CacheLatte/CacheMacro.php
@@ -69,7 +69,8 @@ class CacheMacro implements Latte\IMacro
 	 */
 	public function nodeClosed(Latte\MacroNode $node)
 	{
-		$node->closingCode = '<?php $_tmp = array_pop($this->global->cacheStack); if (!$_tmp instanceof stdClass) $_tmp->end(); } ?>';
+		$node->closingCode = Latte\PhpWriter::using($node)
+			->write('<?php Nette\Bridges\CacheLatte\CacheMacro::endCache($this->global->cacheStack, %node.array?); } ?>');
 	}
 
 
@@ -112,19 +113,26 @@ class CacheMacro implements Latte\IMacro
 
 		$cache = new Cache($cacheStorage, 'Nette.Templating.Cache');
 		if ($helper = $cache->start($key)) {
+			$parents[] = $helper;
+		}
+		return $helper;
+	}
+
+
+	public static function endCache(& $parents, array $args = NULL)
+	{
+		$helper = array_pop($parents);
+		if ($helper instanceof Nette\Caching\OutputHelper) {
 			if (isset($args['dependencies'])) {
 				$args += call_user_func($args['dependencies']);
 			}
 			if (isset($args['expire'])) {
 				$args['expiration'] = $args['expire']; // back compatibility
 			}
-			$helper->dependencies = [
-				$cache::TAGS => isset($args['tags']) ? $args['tags'] : NULL,
-				$cache::EXPIRATION => isset($args['expiration']) ? $args['expiration'] : '+ 7 days',
-			];
-			$parents[] = $helper;
+			$helper->dependencies[Nette\Caching\Cache::TAGS] = isset($args['tags']) ? $args['tags'] : NULL;
+			$helper->dependencies[Nette\Caching\Cache::EXPIRATION] = isset($args['expiration']) ? $args['expiration'] : '+ 7 days';
+			$helper->end();
 		}
-		return $helper;
 	}
 
 }

--- a/tests/Bridges.Latte/CacheMacro.createCache.phpt
+++ b/tests/Bridges.Latte/CacheMacro.createCache.phpt
@@ -15,8 +15,9 @@ require __DIR__ . '/../bootstrap.php';
 test(function () {
 	$parents = [];
 	$dp = [Cache::TAGS => ['rum', 'cola']];
-	$outputHelper = CacheMacro::createCache(new DevNullStorage(), 'test', $parents, $dp);
+	$outputHelper = CacheMacro::createCache(new DevNullStorage(), 'test', $parents);
 	Assert::type(Nette\Caching\OutputHelper::class, $outputHelper);
+	CacheMacro::endCache($parents, $dp);
 	Assert::same($dp + [Cache::EXPIRATION => '+ 7 days'], $outputHelper->dependencies);
 });
 
@@ -26,7 +27,8 @@ test(function () {
 	$dpFallback = function () use ($dp) {
 		return $dp;
 	};
-	$outputHelper = CacheMacro::createCache(new DevNullStorage(), 'test', $parents, ['dependencies' => $dpFallback]);
+	$outputHelper = CacheMacro::createCache(new DevNullStorage(), 'test', $parents);
+	CacheMacro::endCache($parents, ['dependencies' => $dpFallback]);
 	Assert::same($dp + [Cache::EXPIRATION => '+ 7 days'], $outputHelper->dependencies);
 });
 
@@ -39,6 +41,7 @@ test(function () {
 	$dpFallback = function () use ($dp) {
 		return $dp;
 	};
-	$outputHelper = CacheMacro::createCache(new DevNullStorage(), 'test', $parents, ['dependencies' => $dpFallback]);
+	$outputHelper = CacheMacro::createCache(new DevNullStorage(), 'test', $parents);
+	CacheMacro::endCache($parents, ['dependencies' => $dpFallback]);
 	Assert::same($dp, $outputHelper->dependencies);
 });

--- a/tests/Bridges.Latte/expected/CacheMacro.cache.inc.phtml
+++ b/tests/Bridges.Latte/expected/CacheMacro.cache.inc.phtml
@@ -11,8 +11,7 @@ class Template%a% extends Latte\Runtime\Template
 			?>	<?php echo %a% ?>
 
 <?php
-			$_tmp = array_pop($this->global->cacheStack);
-			if (!$_tmp instanceof stdClass) $_tmp->end();
+			Nette\Bridges\CacheLatte\CacheMacro::endCache($this->global->cacheStack);
 		}
 %A%
 	}

--- a/tests/Bridges.Latte/expected/CacheMacro.cache.phtml
+++ b/tests/Bridges.Latte/expected/CacheMacro.cache.phtml
@@ -21,8 +21,7 @@ Noncached content
 ?>
 
 <?php
-			$_tmp = array_pop($this->global->cacheStack);
-			if (!$_tmp instanceof stdClass) $_tmp->end();
+			Nette\Bridges\CacheLatte\CacheMacro::endCache($this->global->cacheStack, [$id, 'tags' => 'mytag']);
 		}
 %A%
 	}


### PR DESCRIPTION
- bug fix? no
- BC break? no

prevents invalid expiration from dependencies callback when caching time-expensive data

example of code causing problem:
```php
$dependencies = function () {
	return [Cache::Expiration => new DateTime('+1 second')];
};
```

```latte
{cache foo dependencies => $dependencies}
	{php sleep(2)} {* loading data *}
	bar
{cache}
```

**current behaviour:**
content is cached with zero expiration (-1 second)

**expected behaviour:**
content is cached for 1 second