### PR TITLE
Cache: do not save data with negative/zero expiration

### DIFF
--- a/src/Caching/Cache.php
+++ b/src/Caching/Cache.php
@@ -186,7 +186,12 @@ class Cache
 		if ($data === NULL) {
 			$this->storage->remove($key);
 		} else {
-			$this->storage->write($key, $data, $this->completeDependencies($dependencies));
+			$dependencies = $this->completeDependencies($dependencies);
+			if (isset($dependencies[Cache::EXPIRATION]) && $dependencies[Cache::EXPIRATION] <= 0) {
+				$this->storage->remove($key);
+			} else {
+				$this->storage->write($key, $data, $dependencies);
+			}
 			return $data;
 		}
 	}

--- a/tests/Caching/Cache.save.phpt
+++ b/tests/Caching/Cache.save.phpt
@@ -50,3 +50,17 @@ $cache->save('key', function () {
 $res = $cache->load('key');
 Assert::equal('value', $res['data']);
 Assert::equal($dependencies, $res['dependencies']);
+
+
+// do not save already expired data
+$storage = new testStorage();
+$cache = new Cache($storage, 'ns');
+$dependencies = [Cache::EXPIRATION => new DateTime];
+
+$res = $cache->save('key', function () {
+	return 'value';
+}, $dependencies);
+Assert::equal('value', $res);
+
+$res = $cache->load('key');
+Assert::null($res);


### PR DESCRIPTION
-  bug fix? no
 - do not save data with negative/zero expiration
- BC break? no


same problem as described in PR https://github.com/nette/caching/pull/49, just another prevention