### PR TITLE
Cleaning namespace in SQLite

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,19 +7,32 @@ Nette Caching
 [![Latest Stable Version](https://poser.pugx.org/nette/caching/v/stable)](https://github.com/nette/caching/releases)
 [![License](https://img.shields.io/badge/license-New%20BSD-blue.svg)](https://github.com/nette/caching/blob/master/license.md)
 
+
+Introduction
+------------
+
 Cache accelerates your application by storing data - once hardly retrieved - for future use.
 
-Install it using Composer:
+Documentation can be found on the [website](https://doc.nette.org/caching).
+
+
+Installation
+------------
+
+The recommended way to install Nette Caching is via Composer:
 
 ```
 composer require nette/caching
 ```
 
-The last stable release requires PHP version 5.6 or newer (is compatible with PHP 7.0 and 7.1). The dev-master version requires PHP 7.1.
+It requires PHP version 5.6 and supports PHP up to 7.2. The dev-master version requires PHP 7.1.
 
-Nette offers a very intuitive API for cache manipulation. After all, you wouldn't expect anything else, right? ;-)
-Before we show you the first example, we need to think about place where to store data physically. We can use a database, //Memcached// server,
-or the most available storage - hard drive:
+
+Usage
+-----
+
+Nette Caching offers a very intuitive API for cache manipulation. Before we show you the first example, we need to think about place where
+to store data physically. We can use a database, Memcached server, or the most available storage - hard drive:
 
 ```php
 // the `temp` directory will be the storage
@@ -82,7 +95,7 @@ $cache = new Cache($storage, 'htmlOutput');
 
 
 Caching Function Results
--------------------------
+------------------------
 
 Caching the result of a function or method call can be achieved using the `call()` method:
 
@@ -94,7 +107,7 @@ The `gethostbyaddr($ip)` will therefore be called only once and next time, only 
 different results are cached.
 
 Output Caching
-------------------
+--------------
 
 The output can be cached not only in templates:
 
@@ -217,9 +230,8 @@ $cache->clean(array(
 ```
 
 
-
 Cache Storage
---------
+-------------
 In addition to already mentioned `FileStorage`, Nette Framework also provides `MemcachedStorage` which stores
 data to the `Memcached` server, and also `MemoryStorage` for storing data in memory for duration of the request.
 The special `DevNullStorage`, which does precisely nothing, can be used for testing, when we want to eliminate the influence of caching.
@@ -238,8 +250,8 @@ The solution is to modify application behaviour so that data are created only by
 or use an anonymous function:
 
 ```php
-$result = $cache->save($key, function() { // or callback(...)
-        return buildData(); // difficult operation
+$result = $cache->save($key, function() {
+	return buildData(); // difficult operation
 });
 ```
 

--- a/tests/Storages/SQLiteStorage.clean-namespace.phpt
+++ b/tests/Storages/SQLiteStorage.clean-namespace.phpt
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * Test: Nette\Caching\Storages\SQLiteStorage clean with Cache::NAMESPACE
+ * @phpExtension pdo_sqlite
+ */
+
+declare(strict_types=1);
+
+use Nette\Caching\Cache;
+use Nette\Caching\Storages\SQLiteStorage;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+$storage = new SQLiteStorage(':memory:');
+
+/*
+ * Create SQLiteStorage cache without namespace and some with namespaces
+ */
+$cacheA = new Cache($storage);
+$cacheB = new Cache($storage, 'C' . Cache::NAMESPACE_SEPARATOR . 'A');
+$cacheC = new Cache($storage, 'C');
+$cacheD = new Cache($storage, 'D');
+
+/*
+ * Fill with data
+ */
+$cacheA->save('test1', 'David');
+$cacheA->save('test2', 'Grudl');
+
+$cacheB->save('test1', 'Barry');
+$cacheB->save('test2', 'Allen');
+
+$cacheC->save('test1', 'Oliver');
+$cacheC->save('test2', 'Queen');
+
+$cacheD->save('test1', 'Bruce');
+$cacheD->save('test2', 'Wayne');
+
+
+/*
+ * Check if fill wass successfull
+ */
+Assert::same('David', $cacheA->load('test1'));
+Assert::same('Grudl', $cacheA->load('test2'));
+
+Assert::same('Barry', $cacheB->load('test1'));
+Assert::same('Allen', $cacheB->load('test2'));
+
+Assert::same('Oliver', $cacheC->load('test1'));
+Assert::same('Queen', $cacheC->load('test2'));
+
+Assert::same('Bruce', $cacheD->load('test1'));
+Assert::same('Wayne', $cacheD->load('test2'));
+
+
+/*
+ * Clean one namespace
+ */
+$storage->clean([Cache::NAMESPACES => [$cacheB->getNamespace()]]);
+
+Assert::same('David', $cacheA->load('test1'));
+Assert::same('Grudl', $cacheA->load('test2'));
+
+// Only these should be null now
+Assert::null($cacheB->load('test1'));
+Assert::null($cacheB->load('test2'));
+
+Assert::same('Oliver', $cacheC->load('test1'));
+Assert::same('Queen', $cacheC->load('test2'));
+
+Assert::same('Bruce', $cacheD->load('test1'));
+Assert::same('Wayne', $cacheD->load('test2'));
+
+
+/*
+ * Test cleaning multiple namespaces
+ */
+$storage->clean([Cache::NAMESPACES => [$cacheC->getNamespace(), $cacheD->getNamespace()]]);
+
+Assert::same('David', $cacheA->load('test1'));
+Assert::same('Grudl', $cacheA->load('test2'));
+
+// All other should be null
+Assert::null($cacheB->load('test1'));
+Assert::null($cacheB->load('test2'));
+
+Assert::null($cacheC->load('test1'));
+Assert::null($cacheC->load('test2'));
+
+Assert::null($cacheD->load('test1'));
+Assert::null($cacheD->load('test2'));


### PR DESCRIPTION
- new feature? yes, related to #52
- BC break? yes

In SQLite is not possible to combine operator LIKE with string that contains \x00 character (ie NAMESPACE separator). Solution is change \x00 to \x01. 