### PR TITLE
SQLiteJournal: Ignore nullable tags

### DIFF
--- a/src/Caching/Storages/SQLiteJournal.php
+++ b/src/Caching/Storages/SQLiteJournal.php
@@ -72,10 +72,13 @@ class SQLiteJournal implements IJournal
 
 		if (!empty($dependencies[Cache::TAGS])) {
 			$this->pdo->prepare('DELETE FROM tags WHERE key = ?')->execute([$key]);
+			$arr = [];
 
 			foreach ($dependencies[Cache::TAGS] as $tag) {
-				$arr[] = $key;
-				$arr[] = $tag;
+				if ($tag !== null) {
+					$arr[] = $key;
+					$arr[] = $tag;
+				}
 			}
 			$this->pdo->prepare('INSERT INTO tags (key, tag) SELECT ?, ?' . str_repeat('UNION SELECT ?, ?', count($arr) / 2 - 1))
 				->execute($arr);


### PR DESCRIPTION
- new feature
- BC break? yes

I think nullable tags should be ignored, because tag list can be generated dynamically.

For instance:

![Snímek obrazovky 2020-02-11 v 10 58 07](https://user-images.githubusercontent.com/4738758/74226738-64174d00-4cbd-11ea-8bb6-e2f2a34f58cf.png)

Thanks.