### PR TITLE
SQLiteJournal: speed up cache writing, prevent database locked error

### DIFF
--- a/src/Caching/Storages/SQLiteJournal.php
+++ b/src/Caching/Storages/SQLiteJournal.php
@@ -59,6 +59,7 @@ class SQLiteJournal implements Journal
 			CREATE UNIQUE INDEX IF NOT EXISTS idx_tags_key_tag ON tags(key, tag);
 			CREATE UNIQUE INDEX IF NOT EXISTS idx_priorities_key ON priorities(key);
 			CREATE INDEX IF NOT EXISTS idx_priorities_priority ON priorities(priority);
+			PRAGMA synchronous = NORMAL;
 		');
 	}
 


### PR DESCRIPTION
- closes #65
- BC break? no

see also: https://forum.nette.org/cs/24571-nette-caching-sqllitejournal-velmi-pomaly

Tested on production server as well. It helped to prevent DB locked errors.
