### PR TITLE
$dependencies as a 3rd Cache::load() parameter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
 	],
 	"require": {
 		"php": ">=8.0 <8.3",
-		"nette/utils": "^4.0"
+		"nette/finder": "^2.4 || ^3.0",
+		"nette/utils": "^2.4 || ^3.0"
 	},
 	"require-dev": {
 		"nette/tester": "^2.4",

--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,11 @@
 	],
 	"require": {
 		"php": ">=8.0 <8.3",
-		"nette/finder": "^2.4 || ^3.0",
-		"nette/utils": "^2.4 || ^3.0"
+		"nette/utils": "^4.0"
 	},
 	"require-dev": {
 		"nette/tester": "^2.4",
-		"nette/di": "^3.1 || ^4.0",
+		"nette/di": "^v4.0",
 		"latte/latte": "^2.11 || ^3.0",
 		"tracy/tracy": "^2.8",
 		"phpstan/phpstan": "^1.0"

--- a/readme.md
+++ b/readme.md
@@ -131,6 +131,14 @@ $value = $cache->load($key, function (&$dependencies) {
 ]);
 ```
 
+Or using the `$dependencies` as a 3rd parameter in the `load()` method, eg:
+
+```php
+$value = $cache->load($key, function () {
+	return ...;
+], [Cache::Expire => '20 minutes']);
+```
+
 In the following examples, we will assume the second variant and thus the existence of a variable `$dependencies`.
 
 

--- a/src/Caching/Cache.php
+++ b/src/Caching/Cache.php
@@ -179,14 +179,13 @@ class Cache
 	/**
 	 * Writes item into the cache.
 	 * Dependencies are:
-	 * - Cache::Priortiy => (int) priority
-	 * - Cache::Exprie => (timestamp) expiration
+	 * - Cache::Priority => (int) priority
+	 * - Cache::Expire => (timestamp) expiration
 	 * - Cache::Sliding => (bool) use sliding expiration?
 	 * - Cache::Tags => (array) tags
 	 * - Cache::Files => (array|string) file names
 	 * - Cache::Items => (array|string) cache items
-	 * - Cache::Consts => (array|string) cache items
-	 *
+	 * - Cache::Constants => (array|string) cache items
 	 * @return mixed  value itself
 	 * @throws Nette\InvalidArgumentException
 	 */

--- a/src/Caching/Cache.php
+++ b/src/Caching/Cache.php
@@ -110,7 +110,7 @@ class Cache
 	/**
 	 * Reads the specified item from the cache or generate it.
 	 */
-	public function load(mixed $key, ?callable $generator = null): mixed
+	public function load(mixed $key, ?callable $generator = null, ?array $dependencies = null): mixed
 	{
 		$storageKey = $this->generateKey($key);
 		$data = $this->storage->read($storageKey);

--- a/tests/Caching/Cache.load.phpt
+++ b/tests/Caching/Cache.load.phpt
@@ -42,6 +42,15 @@ Assert::same('value', $data['data']);
 Assert::same($dependencies, $data['dependencies']);
 
 
+$value = $cache->load('key2', fn() => 'value2', $dependencies);
+Assert::same('value2', $value);
+
+$data = $cache->load('key2', fn() => "won't load this value");
+Assert::same('value2', $data['data']);
+Assert::same($dependencies, $data['dependencies']);
+
+
+
 // load twice with fallback, pass dependencies
 function fallback(&$deps)
 {
@@ -50,8 +59,8 @@ function fallback(&$deps)
 }
 
 
-$value = $cache->load('key2', 'fallback');
+$value = $cache->load('key3', 'fallback');
 Assert::same('value', $value);
-$data = $cache->load('key2');
+$data = $cache->load('key3');
 Assert::same('value', $data['data']);
 Assert::same($dependencies, $data['dependencies']);


### PR DESCRIPTION
I think pass dependencies as a 3rd `Cache::load()` argument have use cases, even it is not so lazy. For example, I already have data loader defined elsewhere:

```php
$data = $cache->load('key', $client->getDataLoader(), [Cache::Expire => '10 minutes']);

# vs.

$data = $cache->load('key', function (&$dep) use ($client) {
    $dep[Cache::Expire => '10 minutes'];
    return ($client->getDataLoader())();
});
```