### PR TITLE
Bulk write implementation

### DIFF
--- a/src/Caching/BulkWriter.php
+++ b/src/Caching/BulkWriter.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This file is part of the Nette Framework (https://nette.org)
+ * Copyright (c) 2004 David Grudl (https://davidgrudl.com)
+ */
+
+declare(strict_types=1);
+
+namespace Nette\Caching;
+
+
+/**
+ * Cache storage with a bulk write support.
+ */
+interface BulkWriter
+{
+    /**
+	 * Writes to cache in bulk.
+     * <p>Similar to <code>write()</code>, but instead of a single key/value item, it works on multiple items specified in <code>items</code></p>
+     *
+     * @param array{string, mixed} $items <p>An array of key/data pairs to store on the server</p>
+     * @param array $dp Global dependencies of each stored value
+     * @return bool <p>Returns <b><code>true</code></b> on success or <b><code>false</code></b> on failure</p>
+     * @throws Nette\NotSupportedException
+     * @throws Nette\InvalidStateException
+     */
+    function bulkWrite(array $items, array $dp): bool;
+}

--- a/src/Caching/BulkWriter.php
+++ b/src/Caching/BulkWriter.php
@@ -16,7 +16,7 @@ namespace Nette\Caching;
 interface BulkWriter
 {
     /**
-	 * Writes to cache in bulk.
+     * Writes to cache in bulk.
      * <p>Similar to <code>write()</code>, but instead of a single key/value item, it works on multiple items specified in <code>items</code></p>
      *
      * @param array{string, mixed} $items <p>An array of key/data pairs to store on the server</p>

--- a/src/Caching/BulkWriter.php
+++ b/src/Caching/BulkWriter.php
@@ -22,8 +22,8 @@ interface BulkWriter
      * @param array{string, mixed} $items <p>An array of key/data pairs to store on the server</p>
      * @param array $dp Global dependencies of each stored value
      * @return bool <p>Returns <b><code>true</code></b> on success or <b><code>false</code></b> on failure</p>
-     * @throws Nette\NotSupportedException
-     * @throws Nette\InvalidStateException
+     * @throws \Nette\NotSupportedException
+     * @throws \Nette\NotSupportedException
      */
     function bulkWrite(array $items, array $dp): bool;
 

--- a/src/Caching/BulkWriter.php
+++ b/src/Caching/BulkWriter.php
@@ -26,4 +26,9 @@ interface BulkWriter
      * @throws Nette\InvalidStateException
      */
     function bulkWrite(array $items, array $dp): bool;
+
+    /**
+     * Removes multiple items from cache
+     */
+    function bulkRemove(array $keys): void;
 }

--- a/src/Caching/BulkWriter.php
+++ b/src/Caching/BulkWriter.php
@@ -8,6 +8,8 @@
 declare(strict_types=1);
 
 namespace Nette\Caching;
+use Nette\InvalidStateException;
+use Nette\NotSupportedException;
 
 
 /**
@@ -15,20 +17,20 @@ namespace Nette\Caching;
  */
 interface BulkWriter
 {
-    /**
-     * Writes to cache in bulk.
-     * <p>Similar to <code>write()</code>, but instead of a single key/value item, it works on multiple items specified in <code>items</code></p>
-     *
-     * @param array{string, mixed} $items <p>An array of key/data pairs to store on the server</p>
-     * @param array $dp Global dependencies of each stored value
-     * @return bool <p>Returns <b><code>true</code></b> on success or <b><code>false</code></b> on failure</p>
-     * @throws \Nette\NotSupportedException
-     * @throws \Nette\NotSupportedException
-     */
-    function bulkWrite(array $items, array $dp): bool;
+	/**
+	 * Writes to cache in bulk.
+	 * <p>Similar to <code>write()</code>, but instead of a single key/value item, it works on multiple items specified in <code>items</code></p>
+	 *
+	 * @param array{string, mixed} $items <p>An array of key/data pairs to store on the server</p>
+	 * @param array $dp Global dependencies of each stored value
+	 * @return bool <p>Returns <b><code>true</code></b> on success or <b><code>false</code></b> on failure</p>
+	 * @throws NotSupportedException
+	 * @throws InvalidStateException
+	 */
+	function bulkWrite(array $items, array $dp): bool;
 
-    /**
-     * Removes multiple items from cache
-     */
-    function bulkRemove(array $keys): void;
+	/**
+	 * Removes multiple items from cache
+	 */
+	function bulkRemove(array $keys): void;
 }

--- a/src/Caching/Cache.php
+++ b/src/Caching/Cache.php
@@ -186,10 +186,10 @@ class Cache
 	{
 		$storedItems = [];
 
-        if (!$this->storage instanceof BulkWriter) {
+		if (!$this->storage instanceof BulkWriter) {
 
-            foreach ($items as $key => $data) {
-				$storedItems[] = $this->save($key, $data, $dependencies ?? []);
+			foreach ($items as $key => $data) {
+				$storedItems[$key] = $this->save($key, $data, $dependencies);
 			}
 			return $storedItems;
 		}
@@ -202,13 +202,14 @@ class Cache
 		}
 
 		$removals = [];
+		$toCache = [];
 		foreach ($items as $key => $data) {
-			$key = $this->generateKey($key);
+			$cKey = $this->generateKey($key);
 
 			if ($data === null) {
-				$removals[] = $key;
+				$removals[] = $cKey;
 			} else {
-				$storedItems[$key] = $data;
+				$storedItems[$key] = $toCache[$cKey] = $data;
 			}
 		}
 
@@ -216,9 +217,9 @@ class Cache
 			$this->storage->bulkRemove($removals);
 		}
 
-		$this->storage->bulkWrite($storedItems, $dependencies);
-        
-        return $storedItems;
+		$this->storage->bulkWrite($toCache, $dependencies);
+
+		return $storedItems;
 	}
 
 

--- a/src/Caching/Storages/MemcachedStorage.php
+++ b/src/Caching/Storages/MemcachedStorage.php
@@ -25,11 +25,9 @@ class MemcachedStorage implements Nette\Caching\Storage, Nette\Caching\BulkReade
 		MetaDelta = 'delta';
 
 	private \Memcached $memcached;
-	private string $prefix;
-	private ?Journal $journal;
 
 
-	/**
+    /**
 	 * Checks if Memcached extension is available.
 	 */
 	public static function isAvailable(): bool
@@ -38,26 +36,23 @@ class MemcachedStorage implements Nette\Caching\Storage, Nette\Caching\BulkReade
 	}
 
 
-	public function __construct(
+    public function __construct(
 		string $host = 'localhost',
 		int $port = 11211,
-		string $prefix = '',
-		?Journal $journal = null,
-	) {
-		if (!static::isAvailable()) {
+		private string $prefix = '',
+		private ?Journal $journal = null
+    ) {
+        if (!static::isAvailable()) {
 			throw new Nette\NotSupportedException("PHP extension 'memcached' is not loaded.");
-		}
-
-		$this->prefix = $prefix;
-		$this->journal = $journal;
-		$this->memcached = new \Memcached;
-		if ($host) {
-			$this->addServer($host, $port);
-		}
-	}
+        }
+        $this->memcached = new \Memcached;
+        if ($host) {
+            $this->addServer($host, $port);
+        }
+    }
 
 
-	public function addServer(string $host = 'localhost', int $port = 11211): void
+    public function addServer(string $host = 'localhost', int $port = 11211): void
 	{
 		if (@$this->memcached->addServer($host, $port, 1) === false) { // @ is escalated to exception
 			$error = error_get_last();
@@ -208,10 +203,17 @@ class MemcachedStorage implements Nette\Caching\Storage, Nette\Caching\BulkReade
         return $this->memcached->setMulti($records, $expire);
     }
 
+
     public function remove(string $key): void
 	{
 		$this->memcached->delete(urlencode($this->prefix . $key), 0);
 	}
+
+
+    public function bulkRemove(array $keys): void
+    {
+        $this->memcached->deleteMulti(array_map(fn($key) => urlencode($this->prefix . $key), $keys), 0);
+    }
 
 
 	public function clean(array $conditions): void

--- a/tests/Caching/Cache.bulkSave.phpt
+++ b/tests/Caching/Cache.bulkSave.phpt
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Test: Nette\Caching\Cache save().
+ */
+
+declare(strict_types=1);
+
+use Nette\Caching\Cache;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+require __DIR__ . '/Cache.php';
+
+
+test('storage without bulk write support', function () {
+	$storage = new TestStorage;
+	$cache = new Cache($storage, 'ns');
+	Assert::same([1, 2], $cache->bulkSave([1, 2]), 'data');
+	Assert::same([1 => 'value1', 2 => 'value2'], $cache->bulkSave([1 => 'value1', 2 => 'value2']), 'data');
+
+	$data = $cache->bulkLoad([1, 2]);
+	Assert::same('value1', $data[1]['data']);
+	Assert::same('value2', $data[2]['data']);
+});
+
+test('storage with bulk write support', function () {
+	$storage = new BulkWriteTestStorage;
+	$cache = new Cache($storage, 'ns');
+	Assert::same([1, 2], $cache->bulkSave([1, 2]), 'data');
+	Assert::same([1 => 'value1', 2 => 'value2'], $cache->bulkSave([1 => 'value1', 2 => 'value2']), 'data');
+
+	$data = $cache->bulkLoad([1, 2]);
+	Assert::same('value1', $data[1]['data']);
+	Assert::same('value2', $data[2]['data']);
+});
+
+test('dependencies', function () {
+	$storage = new BulkWriteTestStorage;
+	$cache = new Cache($storage, 'ns');
+	$dependencies = [Cache::Tags => ['tag']];
+	$cache->bulkSave([1 => 'value1', 2 => 'value2'], $dependencies);
+
+	$data = $cache->bulkLoad([1, 2]);
+	Assert::same($dependencies, $data[1]['dependencies']);
+	Assert::same($dependencies, $data[2]['dependencies']);
+
+	$cache->clean($dependencies);
+
+	Assert::same([1 => null, 2 => null], $cache->bulkLoad([1, 2]));
+});

--- a/tests/Caching/Cache.php
+++ b/tests/Caching/Cache.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Nette\Caching\BulkWriter;
 use Nette\Caching\IBulkReader;
 use Nette\Caching\IStorage;
 
@@ -37,6 +38,25 @@ class TestStorage implements IStorage
 
 	public function clean(array $conditions): void
 	{
+		if (!empty($conditions[Nette\Caching\Cache::All])) {
+			$this->data = [];
+			return;
+		}
+
+		//unset based by tags
+		if (!empty($conditions[Nette\Caching\Cache::Tags])) {
+			$unsets = [];
+			foreach ($this->data as $key => $data) {
+				$tags = $data['dependencies'][Nette\Caching\Cache::Tags] ?? null;
+				if (array_intersect($conditions[Nette\Caching\Cache::Tags], $tags)) {
+					$unsets[$key] = $key;
+				}
+			}
+
+			foreach ($unsets as $unsetKey) {
+				unset($this->data[$unsetKey]);
+			}
+		}
 	}
 }
 
@@ -53,5 +73,37 @@ class BulkReadTestStorage extends TestStorage implements IBulkReader
 		}
 
 		return $result;
+	}
+}
+
+class BulkWriteTestStorage extends TestStorage implements BulkWriter
+{
+	public function bulkRead(array $keys): array
+	{
+		$result = [];
+		foreach ($keys as $key) {
+			$data = $this->read($key);
+			if ($data !== null) {
+				$result[$key] = $data;
+			}
+		}
+
+		return $result;
+	}
+
+
+	public function bulkRemove(array $keys): void
+	{
+
+	}
+
+
+	public function bulkWrite($items, array $dp): bool
+	{
+		foreach ($items as $key => $data) {
+			$this->write($key, $data, $dp);
+		}
+
+		return true;
 	}
 }

--- a/tests/Storages/Memcached.bulkWrite.phpt
+++ b/tests/Storages/Memcached.bulkWrite.phpt
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Test: Nette\Caching\Storages\MemcachedStorage and bulkWrite
+ */
+
+declare(strict_types=1);
+
+use Nette\Caching\Cache;
+use Nette\Caching\Storages\MemcachedStorage;
+use Nette\Caching\Storages\SQLiteJournal;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+if (!MemcachedStorage::isAvailable()) {
+	Tester\Environment::skip('Requires PHP extension Memcached.');
+}
+
+Tester\Environment::lock('memcached-files', getTempDir());
+
+
+$storage = new MemcachedStorage('localhost', 11211, '', new SQLiteJournal(getTempDir() . '/journal-memcached.s3db'));
+$cache = new Cache($storage);
+
+//standard
+$cache->bulkSave(["foo" => "bar"]);
+Assert::same(['foo' => 'bar', 'lorem' => null], $cache->bulkLoad(['foo', 'lorem']));
+
+//tags
+$dependencies = [Cache::Tags => ['tag']];
+$cache->bulkSave(["foo" => "bar"], $dependencies);
+Assert::same(['foo' => 'bar'], $cache->bulkLoad(['foo']));
+$cache->clean($dependencies);
+Assert::same(['foo' => null], $cache->bulkLoad(['foo']));


### PR DESCRIPTION
- new feature
- BC break? no
- doc PR:  _TBD after discussion_

This PR implements the functionality of `Memcached::setMulti()` and `Memcached::deleteMulti()` methods available in php `memcached` extension. Adds `BulkWriter` interface (along existing BulkReader), so in the future another storages can have their multiple save / delete implementations (Redis e.t.c.)

Storing multiple data using batch functions has significal performance impact on storing / removing proccess.

We used this implementation in our project, so I finally decided to share it with others