### PR TITLE
Fix/unhandled foreach

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor
 /composer.lock
+/nbproject

--- a/src/Caching/Storages/MemcachedStorage.php
+++ b/src/Caching/Storages/MemcachedStorage.php
@@ -106,6 +106,9 @@ class MemcachedStorage implements Nette\Caching\Storage, Nette\Caching\BulkReade
 		$prefixedKeys = array_map(fn($key) => urlencode($this->prefix . $key), $keys);
 		$keys = array_combine($prefixedKeys, $keys);
 		$metas = $this->memcached->getMulti($prefixedKeys);
+		if (!$metas) {
+			return [];
+		}
 		$result = [];
 		$deleteKeys = [];
 		foreach ($metas as $prefixedKey => $meta) {


### PR DESCRIPTION
- bug fix #78 
- BC break? no


Return empty array instead of raising warning - same behaviour as in read() function