### PR TITLE
feat: Fix phpstan array type

### DIFF
--- a/src/Caching/BulkWriter.php
+++ b/src/Caching/BulkWriter.php
@@ -17,7 +17,7 @@ interface BulkWriter
 {
 	/**
 	 * Writes to cache in bulk.
-	 * @param array{string, mixed} $items
+	 * @param array<string, mixed> $items
 	 */
 	function bulkWrite(array $items, array $dependencies): void;
 


### PR DESCRIPTION
- bug fix
- BC break? no
PHPStan fails due to wrong brackets used in array type , this is a simple quick fix