### PR TITLE
fix(FileStorage): harden GC against non-cache files (#45)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 .gitattributes  export-ignore
 .github/        export-ignore
 .gitignore      export-ignore
+CLAUDE.md       export-ignore
 ncs.*           export-ignore
 phpstan*.neon   export-ignore
 tests/          export-ignore

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,9 +1,6 @@
-name: Static Analysis (only informative)
+name: Static Analysis
 
-on:
-    push:
-        branches:
-          - master
+on: [push, pull_request]
 
 jobs:
     phpstan:
@@ -18,4 +15,3 @@ jobs:
 
             - run: composer install --no-progress --prefer-dist
             - run: composer phpstan -- --no-progress
-              continue-on-error: true # is only informative

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
                   coverage: none
 
             - run: composer install --no-progress --prefer-dist
-            - run: vendor/bin/tester tests -s -C
+            - run: composer tester
             - if: failure()
               uses: actions/upload-artifact@v4
               with:
@@ -41,12 +41,13 @@ jobs:
                   coverage: none
 
             - run: composer update --no-progress --prefer-dist --prefer-lowest --prefer-stable
-            - run: vendor/bin/tester tests -s -C
+            - run: composer tester
 
 
     code_coverage:
         name: Code Coverage
         runs-on: ubuntu-latest
+        continue-on-error: true
         steps:
             - uses: KeisukeYamashita/memcached-actions@v1
             - uses: actions/checkout@v4
@@ -56,7 +57,7 @@ jobs:
                   coverage: none
 
             - run: composer install --no-progress --prefer-dist
-            - run: vendor/bin/tester -p phpdbg tests -s -C --coverage ./coverage.xml --coverage-src ./src
+            - run: composer tester -- -p phpdbg --coverage ./coverage.xml --coverage-src ./src
             - run: wget https://github.com/php-coveralls/php-coveralls/releases/download/v2.4.3/php-coveralls.phar
             - env:
                   COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,280 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Nette Caching is a PHP library providing flexible caching with multiple storage backends and advanced dependency tracking. It's part of the Nette Framework ecosystem.
+
+**Key features:**
+- Multiple storage backends (FileStorage, MemcachedStorage, SQLiteStorage, MemoryStorage)
+- Advanced dependency tracking (tags, priorities, file changes, callbacks)
+- Cache stampede prevention in FileStorage
+- Atomic operations with file locking
+- PSR-16 SimpleCache adapter
+- Latte template integration with `{cache}` tag
+- Nette DI integration
+
+**Requirements:** PHP 8.1-8.5
+
+## Essential Commands
+
+### Testing
+
+```bash
+# Run all tests
+vendor/bin/tester tests -s
+
+# Run specific test directory
+vendor/bin/tester tests/Caching -s
+vendor/bin/tester tests/Storages -s
+
+# Run single test file
+php tests/Caching/Cache.bulkLoad.phpt
+```
+
+### Static Analysis
+
+```bash
+# Run PHPStan (level 5)
+composer run phpstan
+
+# Or directly
+vendor/bin/phpstan analyse
+```
+
+### Linting
+
+```bash
+# Nette coding standard checks
+composer run tester
+```
+
+## Architecture Overview
+
+### Core Layering
+
+The library follows a clean separation of concerns:
+
+```
+Cache (high-level API)
+  ↓
+Storage interface (abstraction)
+  ↓
+Storage implementations (FileStorage, MemcachedStorage, etc.)
+  ↓
+Journal interface (for tags/priorities)
+  ↓
+SQLiteJournal implementation
+```
+
+**Cache** (`src/Caching/Cache.php`): Primary API for caching operations. Provides namespace isolation, dependency tracking, memoization (`wrap()`, `call()`), and output capturing (`capture()`, was `start()` in v3.0).
+
+**Storage interface** (`src/Caching/Storage.php`): Defines the contract all storage backends must implement:
+- `read(string $key): mixed`
+- `write(string $key, $data, array $dependencies): void`
+- `remove(string $key): void`
+- `clean(array $conditions): void`
+- `lock(string $key): void` - Prevents concurrent writes
+
+**Journal interface** (`src/Caching/Storages/Journal.php`): Tracks metadata for tags and priorities. Required for:
+- `Cache::Tags` - Tag-based invalidation
+- `Cache::Priority` - Priority-based cleanup
+
+Default implementation: SQLiteJournal using SQLite database at `{tempDir}/journal.s3db`.
+
+### Storage Implementations
+
+All in `src/Caching/Storages/`:
+
+- **FileStorage** - Production default. Files stored in temp directory with atomic operations via file locking (LOCK_SH for reads, LOCK_EX for writes). Implements cache stampede prevention: when cache miss occurs with concurrent requests, only first thread generates value, others wait. File format: 6-byte header with meta size + serialized metadata + data.
+
+- **SQLiteStorage** - Single-file database storage. Good for shared hosting environments.
+
+- **MemcachedStorage** - Distributed caching via Memcached server. Requires `memcached` PHP extension.
+
+- **MemoryStorage** - In-memory array storage, lost after request. Used for testing or request-scoped caching.
+
+- **DevNullStorage** - No-op storage for testing when you want to disable caching.
+
+### Dependency System
+
+Cache dependencies control expiration and invalidation. All use Cache class constants:
+
+- `Cache::Expire` - Time-based expiration (timestamp, seconds, or string like "20 minutes")
+- `Cache::Sliding` - Extends expiration on each read
+- `Cache::Files` - Invalidate when file(s) modified (checks filemtime)
+- `Cache::Items` - Invalidate when other cache items expire
+- `Cache::Tags` - Tag-based invalidation (requires Journal)
+- `Cache::Priority` - Priority-based cleanup (requires Journal)
+- `Cache::Callbacks` - Custom validation callbacks
+- `Cache::Constants` - Invalidate when PHP constants change
+
+Dependencies can be combined; cache expires when ANY criterion fails.
+
+### Bridge Components
+
+**Nette DI Bridge** (`src/Bridges/CacheDI/CacheExtension.php`):
+- Auto-registers Storage service (FileStorage by default)
+- Auto-registers Journal service (SQLiteJournal if pdo_sqlite available)
+- Validates and creates temp directory
+- Services registered: `cache.storage`, `cache.journal`
+
+**Latte Bridge** (`src/Bridges/CacheLatte/`):
+- Provides `{cache}` tag for template caching
+- Runtime in `Runtime.php` manages cache lifecycle
+- Node compilation in `Nodes/CacheNode.php`
+- Automatic invalidation when template source changes
+- Supports parameters: `{cache $id, expire: '20 minutes', tags: [tag1, tag2]}`
+- Can be conditional: `{cache $id, if: !$form->isSubmitted()}`
+
+**PSR-16 Bridge** (`src/Bridges/Psr/PsrCacheAdapter.php`):
+- Adapts Nette Storage to PSR-16 SimpleCache interface
+- Used for PSR compatibility in third-party integrations
+
+### Bulk Operations
+
+Two specialized classes enable efficient bulk operations:
+
+- **BulkReader** (`src/Caching/BulkReader.php`) - Interface for storages supporting bulk reads
+- **BulkWriter** (`src/Caching/BulkWriter.php`) - Interface for storages supporting bulk writes
+
+Used by `Cache::bulkLoad()` and `Cache::bulkSave()` to reduce storage round-trips.
+
+## Testing Structure
+
+Tests organized by component in `tests/`:
+- `Caching/` - Cache class tests
+- `Storages/` - Storage implementation tests
+- `Bridges.DI/` - Nette DI integration tests
+- `Bridges.Latte3/` - Latte 3.x template caching tests
+- `Bridges.Psr/` - PSR-16 adapter tests
+
+Test utilities:
+- `bootstrap.php` - Test environment setup with `test()` helper function
+- `getTempDir()` - Creates isolated temp directory per test process
+- Uses Nette Tester with `.phpt` format
+
+## Development Notes
+
+### File Locking Strategy (FileStorage)
+
+Three atomic operation types documented in FileStorage.php:
+1. **Reading**: open(r+b) → lock(LOCK_SH) → read → close
+2. **Deleting**: unlink, if fails lock(LOCK_EX) → truncate → close → unlink
+3. **Writing**: open(r+b or wb) → lock(LOCK_EX) → truncate → write data → write meta → close
+
+This ensures atomicity on both NTFS and ext3 filesystems.
+
+### Cache Stampede Prevention
+
+FileStorage prevents cache stampede through locking: when multiple concurrent threads request non-existent cache item, `lock()` ensures only first thread generates value while others wait. Others then use the generated result.
+
+### Namespace Handling
+
+Cache uses internal null byte separator (`Cache::NamespaceSeparator = "\x00"`) to isolate namespaces. Keys are prefixed with `{namespace}\x00{key}`.
+
+### Constants Naming
+
+Library uses modern PascalCase constants (e.g., `Cache::Expire`) with deprecated UPPERCASE aliases (e.g., `Cache::EXPIRATION`) for backward compatibility.
+
+**Version 3.0 compatibility note:** In version 3.0, the Storage interface was named `IStorage` (with `I` prefix) and constants were UPPERCASE (e.g., `Cache::EXPIRE` instead of `Cache::Expire`).
+
+## Using Cache in Code
+
+Two approaches for dependency injection:
+
+**Approach 1: Inject Storage, create Cache manually**
+```php
+class ClassOne
+{
+	private Nette\Caching\Cache $cache;
+
+	public function __construct(Nette\Caching\Storage $storage)
+	{
+		$this->cache = new Nette\Caching\Cache($storage, 'my-namespace');
+	}
+}
+```
+
+**Approach 2: Inject Cache directly**
+```php
+class ClassTwo
+{
+	public function __construct(
+		private Nette\Caching\Cache $cache,
+	) {
+	}
+}
+```
+
+Configuration for Approach 2:
+```neon
+services:
+	- ClassTwo( Nette\Caching\Cache(namespace: 'my-namespace') )
+```
+
+## DI Services
+
+Services automatically registered by CacheExtension:
+
+| Service Name | Type | Description |
+|--------------|------|-------------|
+| `cache.storage` | `Nette\Caching\Storage` | Primary cache storage (FileStorage by default) |
+| `cache.journal` | `Nette\Caching\Storages\Journal` | Journal for tags/priorities (SQLiteJournal, requires pdo_sqlite) |
+
+## Configuration Examples
+
+### Change Storage Backend
+
+```neon
+services:
+	cache.storage: Nette\Caching\Storages\DevNullStorage
+```
+
+### Use MemcachedStorage
+
+```neon
+services:
+	cache.storage: Nette\Caching\Storages\MemcachedStorage('10.0.0.5')
+```
+
+### Use SQLiteStorage
+
+```neon
+services:
+	cache.storage: Nette\Caching\Storages\SQLiteStorage('%tempDir%/cache.db')
+```
+
+### Custom Journal
+
+```neon
+services:
+	cache.journal: MyJournal
+```
+
+### Disable Caching (for testing)
+
+```neon
+services:
+	cache.storage: Nette\Caching\Storages\DevNullStorage
+```
+
+**Note:** This doesn't affect Latte template caching or DI container caching, as those are managed independently and [don't need to be disabled during development](https://doc.nette.org/troubleshooting#How-to-Disable-Cache-During-Development).
+
+## PSR-16 Usage
+
+The `PsrCacheAdapter` provides PSR-16 SimpleCache compatibility (available since v3.3.1):
+
+```php
+$psrCache = new Nette\Bridges\Psr\PsrCacheAdapter($storage);
+
+// PSR-16 interface
+$psrCache->set('key', 'value', 3600);
+$value = $psrCache->get('key', 'default');
+
+// Supports all PSR-16 methods
+$psrCache->getMultiple(['key1', 'key2']);
+$psrCache->setMultiple(['key1' => 'val1', 'key2' => 'val2']);
+$psrCache->deleteMultiple(['key1', 'key2']);
+```

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,9 @@
 		"latte/latte": "^3.0.12",
 		"tracy/tracy": "^2.9",
 		"psr/simple-cache": "^2.0 || ^3.0",
-		"phpstan/phpstan-nette": "^2.0@stable"
+		"phpstan/phpstan": "^2.1.40@stable",
+		"phpstan/extension-installer": "^1.4@stable",
+		"nette/phpstan-rules": "^1.0"
 	},
 	"conflict": {
 		"latte/latte": "<3.0.12"
@@ -46,6 +48,11 @@
 	"extra": {
 		"branch-alias": {
 			"dev-master": "3.4-dev"
+		}
+	},
+	"config": {
+		"allow-plugins": {
+			"phpstan/extension-installer": true
 		}
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "3.4-dev"
+			"dev-master": "4.0-dev"
 		}
 	},
 	"config": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 		"nette/utils": "^4.0"
 	},
 	"require-dev": {
-		"nette/tester": "^2.4",
+		"nette/tester": "^2.6",
 		"nette/di": "^3.1 || ^4.0",
 		"latte/latte": "^3.0.12",
 		"tracy/tracy": "^2.9",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,8 +1,31 @@
 parameters:
-	level: 5
+	level: 8
 
 	paths:
 		- src
 
 	excludePaths:
-		- src/Bridges/CacheLatte/CacheMacro.php
+		- src/compatibility.php
+
+	ignoreErrors:
+		-   # Intentional design pattern for derive() and factory methods
+			identifier: new.static
+			paths:
+				- src/Caching/Cache.php
+				- src/Bridges/CacheLatte/Nodes/CacheNode.php
+
+		-   # Intentional by-reference parameter for dependency injection
+			identifier: argument.byRef
+			path: src/Caching/Cache.php
+
+		-   # Runtime validation for untyped array input
+			identifier: function.alreadyNarrowedType
+			path: src/Caching/Cache.php
+
+		-   # PHPStan cannot narrow callable to array shape after is_array() in closure
+			identifier: offsetAccess.nonOffsetAccessible
+			path: src/Caching/Cache.php
+
+		-
+			identifier: method.childParameterType
+			path: src/Bridges/Psr/PsrCacheAdapter.php

--- a/src/Bridges/CacheDI/CacheExtension.php
+++ b/src/Bridges/CacheDI/CacheExtension.php
@@ -43,13 +43,5 @@ final class CacheExtension extends Nette\DI\CompilerExtension
 		$builder->addDefinition($this->prefix('storage'))
 			->setType(Nette\Caching\Storage::class)
 			->setFactory(Nette\Caching\Storages\FileStorage::class, [$this->tempDir]);
-
-		if ($this->name === 'cache') {
-			if (extension_loaded('pdo_sqlite')) {
-				$builder->addAlias('nette.cacheJournal', $this->prefix('journal'));
-			}
-
-			$builder->addAlias('cacheStorage', $this->prefix('storage'));
-		}
 	}
 }

--- a/src/Bridges/CacheDI/CacheExtension.php
+++ b/src/Bridges/CacheDI/CacheExtension.php
@@ -17,7 +17,7 @@ use Nette\Utils\FileSystem;
 final class CacheExtension extends Nette\DI\CompilerExtension
 {
 	public function __construct(
-		private string $tempDir,
+		private readonly string $tempDir,
 	) {
 	}
 

--- a/src/Bridges/CacheLatte/CacheExtension.php
+++ b/src/Bridges/CacheLatte/CacheExtension.php
@@ -20,12 +20,11 @@ use Nette\Caching\Storage;
 final class CacheExtension extends Latte\Extension
 {
 	private bool $used;
-	private Storage $storage;
 
 
-	public function __construct(Storage $storage)
-	{
-		$this->storage = $storage;
+	public function __construct(
+		private readonly Storage $storage,
+	) {
 	}
 
 

--- a/src/Bridges/CacheLatte/CacheExtension.php
+++ b/src/Bridges/CacheLatte/CacheExtension.php
@@ -65,7 +65,7 @@ final class CacheExtension extends Latte\Extension
 	}
 
 
-	public function getCacheKey(Latte\Engine $engine): array
+	public function getCacheKey(Latte\Engine $engine): mixed
 	{
 		return ['version' => 2];
 	}

--- a/src/Bridges/CacheLatte/Nodes/CacheNode.php
+++ b/src/Bridges/CacheLatte/Nodes/CacheNode.php
@@ -25,7 +25,7 @@ class CacheNode extends StatementNode
 	public ?Position $endLine;
 
 
-	/** @return \Generator<int, ?array, array{AreaNode, ?Tag}, static> */
+	/** @return \Generator<int, ?list<string>, array{AreaNode, ?Tag}, static> */
 	public static function create(Tag $tag): \Generator
 	{
 		$node = $tag->node = new static;

--- a/src/Bridges/CacheLatte/Runtime.php
+++ b/src/Bridges/CacheLatte/Runtime.php
@@ -20,7 +20,7 @@ use function array_intersect_key, array_key_exists, array_merge, array_pop, coun
  */
 class Runtime
 {
-	/** @var array<int, OutputHelper|\stdClass> */
+	/** @var list<OutputHelper|\stdClass> */
 	private array $stack = [];
 
 
@@ -43,6 +43,7 @@ class Runtime
 
 	/**
 	 * Starts the output cache. Returns true if buffering was started.
+	 * @param ?array<string, mixed>  $args {if?: bool, tags?: string[], expire?: string, expiration?: string, dependencies?: callable}
 	 */
 	public function createCache(string $key, ?array $args = null): bool
 	{

--- a/src/Bridges/CacheLatte/Runtime.php
+++ b/src/Bridges/CacheLatte/Runtime.php
@@ -25,7 +25,7 @@ class Runtime
 
 
 	public function __construct(
-		private Nette\Caching\Storage $storage,
+		private readonly Nette\Caching\Storage $storage,
 	) {
 	}
 

--- a/src/Bridges/CacheLatte/Runtime.php
+++ b/src/Bridges/CacheLatte/Runtime.php
@@ -11,7 +11,7 @@ use Latte;
 use Nette;
 use Nette\Caching\Cache;
 use Nette\Caching\OutputHelper;
-use function array_intersect_key, array_key_exists, array_merge, array_pop, count, end, is_file, range;
+use function array_intersect_key, array_key_exists, array_merge, array_pop, count, end, is_file, is_string, range;
 
 
 /**
@@ -34,7 +34,7 @@ class Runtime
 	{
 		if ($this->stack) {
 			$file = (new \ReflectionClass($template))->getFileName();
-			if (@is_file($file)) { // @ - may trigger error
+			if (is_string($file) && @is_file($file)) { // @ - may trigger error
 				end($this->stack)->dependencies[Cache::Files][] = $file;
 			}
 		}

--- a/src/Bridges/Psr/PsrCacheAdapter.php
+++ b/src/Bridges/Psr/PsrCacheAdapter.php
@@ -15,7 +15,7 @@ use Psr;
 class PsrCacheAdapter implements Psr\SimpleCache\CacheInterface
 {
 	public function __construct(
-		private Nette\Caching\Storage $storage,
+		private readonly Nette\Caching\Storage $storage,
 	) {
 	}
 

--- a/src/Bridges/Psr/PsrCacheAdapter.php
+++ b/src/Bridges/Psr/PsrCacheAdapter.php
@@ -65,7 +65,7 @@ class PsrCacheAdapter implements Psr\SimpleCache\CacheInterface
 
 
 	/**
-	 * @param iterable<string|int, mixed> $values
+	 * @param iterable<int|string, mixed>  $values
 	 */
 	public function setMultiple(iterable $values, null|int|DateInterval $ttl = null): bool
 	{
@@ -79,6 +79,7 @@ class PsrCacheAdapter implements Psr\SimpleCache\CacheInterface
 	}
 
 
+	/** @param  iterable<int|string, string>  $keys */
 	public function deleteMultiple(iterable $keys): bool
 	{
 		foreach ($keys as $value) {

--- a/src/Caching/BulkReader.php
+++ b/src/Caching/BulkReader.php
@@ -15,7 +15,8 @@ interface BulkReader
 {
 	/**
 	 * Reads from cache in bulk.
-	 * @return array key => value pairs, missing items are omitted
+	 * @param  list<string>  $keys
+	 * @return array<string, mixed>  key => value pairs, missing items are omitted
 	 */
 	function bulkRead(array $keys): array;
 }

--- a/src/Caching/BulkWriter.php
+++ b/src/Caching/BulkWriter.php
@@ -15,12 +15,14 @@ interface BulkWriter
 {
 	/**
 	 * Writes to cache in bulk.
-	 * @param array{string, mixed} $items
+	 * @param  array<string, mixed>  $items
+	 * @param  array<string, mixed>  $dependencies
 	 */
 	function bulkWrite(array $items, array $dependencies): void;
 
 	/**
-	 * Removes multiple items from cache
+	 * Removes multiple items from cache.
+	 * @param  list<string>  $keys
 	 */
 	function bulkRemove(array $keys): void;
 }

--- a/src/Caching/Cache.php
+++ b/src/Caching/Cache.php
@@ -63,9 +63,7 @@ class Cache
 	public const ALL = self::All;
 
 	/** @internal */
-	public const
-		NamespaceSeparator = "\x00",
-		NAMESPACE_SEPARATOR = self::NamespaceSeparator;
+	public const NamespaceSeparator = "\x00";
 
 	private Storage $storage;
 	private string $namespace;
@@ -402,6 +400,7 @@ class Cache
 	 */
 	public function start(mixed $key): ?OutputHelper
 	{
+		trigger_error(__METHOD__ . '() was renamed to capture()', E_USER_DEPRECATED);
 		return $this->capture($key);
 	}
 

--- a/src/Caching/Cache.php
+++ b/src/Caching/Cache.php
@@ -29,37 +29,37 @@ class Cache
 		Namespaces = 'namespaces',
 		All = 'all';
 
-	/** @deprecated use Cache::Priority */
+	#[\Deprecated('use Cache::Priority')]
 	public const PRIORITY = self::Priority;
 
-	/** @deprecated use Cache::Expire */
+	#[\Deprecated('use Cache::Expire')]
 	public const EXPIRATION = self::Expire;
 
-	/** @deprecated use Cache::Expire */
+	#[\Deprecated('use Cache::Expire')]
 	public const EXPIRE = self::Expire;
 
-	/** @deprecated use Cache::Sliding */
+	#[\Deprecated('use Cache::Sliding')]
 	public const SLIDING = self::Sliding;
 
-	/** @deprecated use Cache::Tags */
+	#[\Deprecated('use Cache::Tags')]
 	public const TAGS = self::Tags;
 
-	/** @deprecated use Cache::Files */
+	#[\Deprecated('use Cache::Files')]
 	public const FILES = self::Files;
 
-	/** @deprecated use Cache::Items */
+	#[\Deprecated('use Cache::Items')]
 	public const ITEMS = self::Items;
 
-	/** @deprecated use Cache::Constants */
+	#[\Deprecated('use Cache::Constants')]
 	public const CONSTS = self::Constants;
 
-	/** @deprecated use Cache::Callbacks */
+	#[\Deprecated('use Cache::Callbacks')]
 	public const CALLBACKS = self::Callbacks;
 
-	/** @deprecated use Cache::Namespaces */
+	#[\Deprecated('use Cache::Namespaces')]
 	public const NAMESPACES = self::Namespaces;
 
-	/** @deprecated use Cache::All */
+	#[\Deprecated('use Cache::All')]
 	public const ALL = self::All;
 
 	/** @internal */
@@ -395,9 +395,7 @@ class Cache
 	}
 
 
-	/**
-	 * @deprecated  use capture()
-	 */
+	#[\Deprecated('use capture()')]
 	public function start(mixed $key): ?OutputHelper
 	{
 		trigger_error(__METHOD__ . '() was renamed to capture()', E_USER_DEPRECATED);

--- a/src/Caching/Cache.php
+++ b/src/Caching/Cache.php
@@ -107,6 +107,8 @@ class Cache
 
 	/**
 	 * Reads the specified item from the cache or generate it.
+	 * @param ?(\Closure(mixed &$dependencies): mixed)  $generator
+	 * @param ?array<string, mixed>  $dependencies
 	 */
 	public function load(mixed $key, ?callable $generator = null, ?array $dependencies = null): mixed
 	{
@@ -130,6 +132,10 @@ class Cache
 
 	/**
 	 * Reads multiple items from the cache.
+	 * @template TKey of int|string
+	 * @param list<TKey>  $keys
+	 * @param ?(\Closure(TKey $key, mixed &$dependencies): mixed)  $generator
+	 * @return array<TKey, mixed>
 	 */
 	public function bulkLoad(array $keys, ?callable $generator = null): array
 	{
@@ -184,6 +190,7 @@ class Cache
 	 * - Cache::Files => (array|string) file names
 	 * - Cache::Items => (array|string) cache items
 	 * - Cache::Constants => (array|string) cache items
+	 * @param ?array<string, mixed>  $dependencies
 	 * @return mixed  value itself
 	 * @throws Nette\InvalidArgumentException
 	 */
@@ -218,7 +225,9 @@ class Cache
 
 
 	/**
-	 * Writes multiple items into cache
+	 * Writes multiple items into cache.
+	 * @param mixed[]  $items
+	 * @param ?array<string, mixed>  $dependencies
 	 */
 	public function bulkSave(array $items, ?array $dependencies = null): void
 	{
@@ -256,6 +265,10 @@ class Cache
 	}
 
 
+	/**
+	 * @param ?array<string, mixed>  $dp
+	 * @return array<string, mixed>
+	 */
 	private function completeDependencies(?array $dp): array
 	{
 		// convert expire into relative amount of seconds
@@ -319,6 +332,7 @@ class Cache
 	 * - Cache::Priority => (int) priority
 	 * - Cache::Tags => (array) tags
 	 * - Cache::All => true
+	 * @param ?array<string, mixed>  $conditions
 	 */
 	public function clean(?array $conditions = null): void
 	{
@@ -333,6 +347,7 @@ class Cache
 
 	/**
 	 * Caches results of function/method calls.
+	 * @param  callable(mixed...): mixed  $function
 	 */
 	public function call(callable $function): mixed
 	{
@@ -347,6 +362,9 @@ class Cache
 
 	/**
 	 * Caches results of function/method calls.
+	 * @param  callable(mixed...): mixed  $function
+	 * @param  ?array<string, mixed>  $dependencies
+	 * @return \Closure(mixed...): mixed
 	 */
 	public function wrap(callable $function, ?array $dependencies = null): \Closure
 	{
@@ -402,6 +420,7 @@ class Cache
 
 	/**
 	 * Checks CALLBACKS dependencies.
+	 * @param list<array{0: callable(mixed...): bool, 1?: mixed, 2?: mixed}>  $callbacks
 	 */
 	public static function checkCallbacks(array $callbacks): bool
 	{

--- a/src/Caching/Cache.php
+++ b/src/Caching/Cache.php
@@ -400,7 +400,7 @@ class Cache
 	/**
 	 * @deprecated  use capture()
 	 */
-	public function start($key): ?OutputHelper
+	public function start(mixed $key): ?OutputHelper
 	{
 		return $this->capture($key);
 	}
@@ -409,7 +409,7 @@ class Cache
 	/**
 	 * Generates internal cache key.
 	 */
-	protected function generateKey($key): string
+	protected function generateKey(mixed $key): string
 	{
 		return $this->namespace . hash('xxh128', is_scalar($key) ? (string) $key : serialize($key));
 	}
@@ -437,7 +437,7 @@ class Cache
 	/**
 	 * Checks CONSTS dependency.
 	 */
-	private static function checkConst(string $const, $value): bool
+	private static function checkConst(string $const, mixed $value): bool
 	{
 		return defined($const) && constant($const) === $value;
 	}

--- a/src/Caching/Cache.php
+++ b/src/Caching/Cache.php
@@ -8,7 +8,7 @@
 namespace Nette\Caching;
 
 use Nette;
-use function array_keys, array_map, array_shift, array_slice, array_unique, array_values, constant, count, defined, filemtime, func_get_args, get_class, is_array, is_object, is_scalar, serialize, substr, time;
+use function array_keys, array_map, array_shift, array_slice, array_unique, array_values, constant, count, defined, filemtime, func_get_args, is_array, is_object, is_scalar, serialize, substr, time;
 
 
 /**
@@ -157,7 +157,7 @@ class Cache
 			return $result;
 		}
 
-		$storageKeys = array_map([$this, 'generateKey'], $keys);
+		$storageKeys = array_map($this->generateKey(...), $keys);
 		$cacheData = $this->storage->bulkRead($storageKeys);
 		foreach ($keys as $i => $key) {
 			$storageKey = $storageKeys[$i];
@@ -233,7 +233,7 @@ class Cache
 
 		$dependencies = $this->completeDependencies($dependencies);
 		if (isset($dependencies[self::Expire]) && $dependencies[self::Expire] <= 0) {
-			$this->storage->bulkRemove(array_map(fn($key) => $this->generateKey($key), array_keys($items)));
+			$this->storage->bulkRemove(array_map($this->generateKey(...), array_keys($items)));
 			return;
 		}
 
@@ -284,7 +284,7 @@ class Cache
 
 		// add namespaces to items
 		if (isset($dp[self::Items])) {
-			$dp[self::Items] = array_unique(array_map([$this, 'generateKey'], (array) $dp[self::Items]));
+			$dp[self::Items] = array_unique(array_map($this->generateKey(...), (array) $dp[self::Items]));
 		}
 
 		// convert CONSTS into CALLBACKS
@@ -338,7 +338,7 @@ class Cache
 	{
 		$key = func_get_args();
 		if (is_array($function) && is_object($function[0])) {
-			$key[0][0] = get_class($function[0]);
+			$key[0][0] = $function[0]::class;
 		}
 
 		return $this->load($key, fn() => $function(...array_slice($key, 1)));
@@ -353,7 +353,7 @@ class Cache
 		return function () use ($function, $dependencies) {
 			$key = [$function, $args = func_get_args()];
 			if (is_array($function) && is_object($function[0])) {
-				$key[0][0] = get_class($function[0]);
+				$key[0][0] = $function[0]::class;
 			}
 
 			return $this->load($key, function (&$deps) use ($function, $args, $dependencies) {

--- a/src/Caching/OutputHelper.php
+++ b/src/Caching/OutputHelper.php
@@ -16,14 +16,12 @@ use Nette;
 class OutputHelper
 {
 	public array $dependencies = [];
-	private ?Cache $cache;
-	private mixed $key;
 
 
-	public function __construct(Cache $cache, mixed $key)
-	{
-		$this->cache = $cache;
-		$this->key = $key;
+	public function __construct(
+		private ?Cache $cache,
+		private mixed $key,
+	) {
 		ob_start();
 	}
 

--- a/src/Caching/OutputHelper.php
+++ b/src/Caching/OutputHelper.php
@@ -15,6 +15,7 @@ use Nette;
  */
 class OutputHelper
 {
+	/** @var array<string, mixed> */
 	public array $dependencies = [];
 
 
@@ -28,6 +29,7 @@ class OutputHelper
 
 	/**
 	 * Stops and saves the cache.
+	 * @param  array<string, mixed>  $dependencies
 	 */
 	public function end(array $dependencies = []): void
 	{

--- a/src/Caching/Storage.php
+++ b/src/Caching/Storage.php
@@ -15,9 +15,8 @@ interface Storage
 {
 	/**
 	 * Read from cache.
-	 * @return mixed
 	 */
-	function read(string $key);
+	function read(string $key): mixed;
 
 	/**
 	 * Prevents item reading and writing. Lock is released by write() or remove().

--- a/src/Caching/Storage.php
+++ b/src/Caching/Storage.php
@@ -26,6 +26,7 @@ interface Storage
 
 	/**
 	 * Writes item into the cache.
+	 * @param  array<string, mixed>  $dependencies
 	 */
 	function write(string $key, $data, array $dependencies): void;
 
@@ -36,6 +37,7 @@ interface Storage
 
 	/**
 	 * Removes items from the cache by conditions.
+	 * @param  array<string, mixed>  $conditions
 	 */
 	function clean(array $conditions): void;
 }

--- a/src/Caching/Storage.php
+++ b/src/Caching/Storage.php
@@ -28,7 +28,7 @@ interface Storage
 	 * Writes item into the cache.
 	 * @param  array<string, mixed>  $dependencies
 	 */
-	function write(string $key, $data, array $dependencies): void;
+	function write(string $key, mixed $data, array $dependencies): void;
 
 	/**
 	 * Removes item from the cache.

--- a/src/Caching/Storages/DevNullStorage.php
+++ b/src/Caching/Storages/DevNullStorage.php
@@ -26,7 +26,7 @@ class DevNullStorage implements Nette\Caching\Storage
 	}
 
 
-	public function write(string $key, $data, array $dependencies): void
+	public function write(string $key, mixed $data, array $dependencies): void
 	{
 	}
 

--- a/src/Caching/Storages/FileStorage.php
+++ b/src/Caching/Storages/FileStorage.php
@@ -50,6 +50,8 @@ class FileStorage implements Nette\Caching\Storage
 
 	private string $dir;
 	private ?Journal $journal;
+
+	/** @var array<string, resource>  key => file handle */
 	private array $locks;
 
 
@@ -79,6 +81,7 @@ class FileStorage implements Nette\Caching\Storage
 
 	/**
 	 * Verifies dependencies.
+	 * @param  array<string, mixed>  $meta
 	 */
 	private function verify(array $meta): bool
 	{
@@ -133,6 +136,7 @@ class FileStorage implements Nette\Caching\Storage
 	}
 
 
+	/** @param  array<string, mixed>  $dp */
 	public function write(string $key, $data, array $dp): void
 	{
 		$meta = [
@@ -221,6 +225,7 @@ class FileStorage implements Nette\Caching\Storage
 	}
 
 
+	/** @param  array<string, mixed>  $conditions */
 	public function clean(array $conditions): void
 	{
 		$all = !empty($conditions[Cache::All]);
@@ -290,6 +295,7 @@ class FileStorage implements Nette\Caching\Storage
 
 	/**
 	 * Reads cache data from disk.
+	 * @return ?array<string, mixed>  meta data with 'file' and 'handle' keys added, or null if not found
 	 */
 	protected function readMetaAndLock(string $file, int $lock): ?array
 	{
@@ -317,6 +323,7 @@ class FileStorage implements Nette\Caching\Storage
 
 	/**
 	 * Reads cache data from disk and closes cache file handle.
+	 * @param  array<string, mixed>  $meta
 	 */
 	protected function readData(array $meta): mixed
 	{

--- a/src/Caching/Storages/FileStorage.php
+++ b/src/Caching/Storages/FileStorage.php
@@ -137,7 +137,7 @@ class FileStorage implements Nette\Caching\Storage
 
 
 	/** @param  array<string, mixed>  $dp */
-	public function write(string $key, $data, array $dp): void
+	public function write(string $key, mixed $data, array $dp): void
 	{
 		$meta = [
 			self::MetaTime => microtime(),

--- a/src/Caching/Storages/FileStorage.php
+++ b/src/Caching/Storages/FileStorage.php
@@ -309,13 +309,14 @@ class FileStorage implements Nette\Caching\Storage
 
 		$size = (int) stream_get_contents($handle, self::MetaHeaderLen);
 		if ($size) {
-			$meta = stream_get_contents($handle, $size, self::MetaHeaderLen);
-			if ($meta !== false) {
-				$meta = unserialize($meta);
-				assert(is_array($meta));
-				$meta[self::File] = $file;
-				$meta[self::Handle] = $handle;
-				return $meta;
+			$raw = stream_get_contents($handle, $size, self::MetaHeaderLen);
+			if ($raw !== false) {
+				$meta = @unserialize($raw); // @ - file may not be a valid cache file
+				if (is_array($meta)) {
+					$meta[self::File] = $file;
+					$meta[self::Handle] = $handle;
+					return $meta;
+				}
 			}
 		}
 
@@ -337,7 +338,7 @@ class FileStorage implements Nette\Caching\Storage
 		return match (true) {
 			$data === false => null,
 			empty($meta[self::MetaSerialized]) => $data,
-			default => unserialize($data),
+			default => @unserialize($data), // @ - data may be corrupted by a truncated write
 		};
 	}
 

--- a/src/Caching/Storages/Journal.php
+++ b/src/Caching/Storages/Journal.php
@@ -15,12 +15,14 @@ interface Journal
 {
 	/**
 	 * Writes entry information into the journal.
+	 * @param  array<string, mixed>  $dependencies  {Cache::Tags => string[], Cache::Priority => int}
 	 */
 	function write(string $key, array $dependencies): void;
 
 	/**
 	 * Cleans entries from journal.
-	 * @return array|null of removed items or null when performing a full cleanup
+	 * @param  array<string, mixed>  $conditions  {Cache::Tags => string[], Cache::Priority => int, Cache::All => bool}
+	 * @return list<string>|null  array of removed keys or null when performing a full cleanup
 	 */
 	function clean(array $conditions): ?array;
 }

--- a/src/Caching/Storages/MemcachedStorage.php
+++ b/src/Caching/Storages/MemcachedStorage.php
@@ -23,9 +23,7 @@ class MemcachedStorage implements Nette\Caching\Storage, Nette\Caching\BulkReade
 		MetaData = 'data',
 		MetaDelta = 'delta';
 
-	private \Memcached $memcached;
-	private string $prefix;
-	private ?Journal $journal;
+	private readonly \Memcached $memcached;
 
 
 	/**
@@ -40,15 +38,12 @@ class MemcachedStorage implements Nette\Caching\Storage, Nette\Caching\BulkReade
 	public function __construct(
 		string $host = 'localhost',
 		int $port = 11211,
-		string $prefix = '',
-		?Journal $journal = null,
+		private readonly string $prefix = '',
+		private readonly ?Journal $journal = null,
 	) {
 		if (!static::isAvailable()) {
 			throw new Nette\NotSupportedException("PHP extension 'memcached' is not loaded.");
 		}
-
-		$this->prefix = $prefix;
-		$this->journal = $journal;
 		$this->memcached = new \Memcached;
 		if ($host) {
 			$this->addServer($host, $port);

--- a/src/Caching/Storages/MemcachedStorage.php
+++ b/src/Caching/Storages/MemcachedStorage.php
@@ -55,7 +55,7 @@ class MemcachedStorage implements Nette\Caching\Storage, Nette\Caching\BulkReade
 	{
 		if (@$this->memcached->addServer($host, $port, 1) === false) { // @ is escalated to exception
 			$error = error_get_last();
-			throw new Nette\InvalidStateException("Memcached::addServer(): $error[message].");
+			throw new Nette\InvalidStateException('Memcached::addServer(): ' . ($error['message'] ?? 'unknown error') . '.');
 		}
 	}
 
@@ -216,7 +216,7 @@ class MemcachedStorage implements Nette\Caching\Storage, Nette\Caching\BulkReade
 			$this->memcached->flush();
 
 		} elseif ($this->journal) {
-			foreach ($this->journal->clean($conditions) as $entry) {
+			foreach ($this->journal->clean($conditions) ?? [] as $entry) {
 				$this->memcached->delete($entry, 0);
 			}
 		}

--- a/src/Caching/Storages/MemcachedStorage.php
+++ b/src/Caching/Storages/MemcachedStorage.php
@@ -127,7 +127,7 @@ class MemcachedStorage implements Nette\Caching\Storage, Nette\Caching\BulkReade
 	}
 
 
-	public function write(string $key, $data, array $dp): void
+	public function write(string $key, mixed $data, array $dp): void
 	{
 		if (isset($dp[Cache::Items])) {
 			throw new Nette\NotSupportedException('Dependent items are not supported by MemcachedStorage.');

--- a/src/Caching/Storages/MemoryStorage.php
+++ b/src/Caching/Storages/MemoryStorage.php
@@ -15,6 +15,7 @@ use Nette;
  */
 class MemoryStorage implements Nette\Caching\Storage
 {
+	/** @var array<string, mixed>  key => cached value */
 	private array $data = [];
 
 

--- a/src/Caching/Storages/MemoryStorage.php
+++ b/src/Caching/Storages/MemoryStorage.php
@@ -30,7 +30,7 @@ class MemoryStorage implements Nette\Caching\Storage
 	}
 
 
-	public function write(string $key, $data, array $dependencies): void
+	public function write(string $key, mixed $data, array $dependencies): void
 	{
 		$this->data[$key] = $data;
 	}

--- a/src/Caching/Storages/SQLiteJournal.php
+++ b/src/Caching/Storages/SQLiteJournal.php
@@ -17,18 +17,15 @@ use function count, extension_loaded, implode, is_file, str_repeat, touch;
  */
 class SQLiteJournal implements Journal
 {
-	/** @string */
-	private $path;
 	private \PDO $pdo;
 
 
-	public function __construct(string $path)
-	{
+	public function __construct(
+		private readonly string $path,
+	) {
 		if (!extension_loaded('pdo_sqlite')) {
 			throw new Nette\NotSupportedException('SQLiteJournal requires PHP extension pdo_sqlite which is not loaded.');
 		}
-
-		$this->path = $path;
 	}
 
 
@@ -70,6 +67,7 @@ class SQLiteJournal implements Journal
 		if (!empty($dependencies[Cache::Tags])) {
 			$this->pdo->prepare('DELETE FROM tags WHERE key = ?')->execute([$key]);
 
+			$arr = [];
 			foreach ($dependencies[Cache::Tags] as $tag) {
 				$arr[] = $key;
 				$arr[] = $tag;

--- a/src/Caching/Storages/SQLiteJournal.php
+++ b/src/Caching/Storages/SQLiteJournal.php
@@ -9,7 +9,7 @@ namespace Nette\Caching\Storages;
 
 use Nette;
 use Nette\Caching\Cache;
-use function count, extension_loaded, implode, is_file, str_repeat, touch;
+use function array_values, count, extension_loaded, implode, is_file, str_repeat, touch;
 
 
 /**
@@ -73,7 +73,7 @@ class SQLiteJournal implements Journal
 				$arr[] = $tag;
 			}
 
-			$this->pdo->prepare('INSERT INTO tags (key, tag) SELECT ?, ?' . str_repeat('UNION SELECT ?, ?', count($arr) / 2 - 1))
+			$this->pdo->prepare('INSERT INTO tags (key, tag) SELECT ?, ?' . str_repeat('UNION SELECT ?, ?', intdiv(count($arr), 2) - 1))
 				->execute($arr);
 		}
 
@@ -136,6 +136,6 @@ class SQLiteJournal implements Journal
 		$this->pdo->prepare("DELETE FROM priorities WHERE key IN ($unionSql)")->execute($args);
 		$this->pdo->exec('COMMIT');
 
-		return $keys;
+		return array_values($keys);
 	}
 }

--- a/src/Caching/Storages/SQLiteStorage.php
+++ b/src/Caching/Storages/SQLiteStorage.php
@@ -111,7 +111,7 @@ class SQLiteStorage implements Nette\Caching\Storage, Nette\Caching\BulkReader
 				$arr[] = $tag;
 			}
 
-			$this->pdo->prepare('INSERT INTO tags (key, tag) SELECT ?, ?' . str_repeat('UNION SELECT ?, ?', count($arr) / 2 - 1))
+			$this->pdo->prepare('INSERT INTO tags (key, tag) SELECT ?, ?' . str_repeat('UNION SELECT ?, ?', intdiv(count($arr), 2) - 1))
 				->execute($arr);
 		}
 

--- a/src/Caching/Storages/SQLiteStorage.php
+++ b/src/Caching/Storages/SQLiteStorage.php
@@ -17,7 +17,7 @@ use function array_merge, count, is_file, serialize, str_repeat, time, touch, un
  */
 class SQLiteStorage implements Nette\Caching\Storage, Nette\Caching\BulkReader
 {
-	private \PDO $pdo;
+	private readonly \PDO $pdo;
 
 
 	public function __construct(string $path)
@@ -105,6 +105,7 @@ class SQLiteStorage implements Nette\Caching\Storage, Nette\Caching\BulkReader
 			->execute([$key, serialize($data), $expire, $slide]);
 
 		if (!empty($dependencies[Cache::Tags])) {
+			$arr = [];
 			foreach ($dependencies[Cache::Tags] as $tag) {
 				$arr[] = $key;
 				$arr[] = $tag;

--- a/src/Caching/Storages/SQLiteStorage.php
+++ b/src/Caching/Storages/SQLiteStorage.php
@@ -91,7 +91,7 @@ class SQLiteStorage implements Nette\Caching\Storage, Nette\Caching\BulkReader
 	}
 
 
-	public function write(string $key, $data, array $dependencies): void
+	public function write(string $key, mixed $data, array $dependencies): void
 	{
 		$expire = isset($dependencies[Cache::Expire])
 			? $dependencies[Cache::Expire] + time()

--- a/tests/Bridges.DI/CacheExtension.phpt
+++ b/tests/Bridges.DI/CacheExtension.phpt
@@ -26,8 +26,4 @@ test('', function () {
 
 	$storage = $container->getService('cache.storage');
 	Assert::type(Nette\Caching\Storages\FileStorage::class, $storage);
-
-	// aliases
-	Assert::same($journal, $container->getService('nette.cacheJournal'));
-	Assert::same($storage, $container->getService('cacheStorage'));
 });

--- a/tests/Bridges.Latte3/expected/cache.inc.php
+++ b/tests/Bridges.Latte3/expected/cache.inc.php
@@ -1,12 +1,12 @@
 <?php
 %A%
-		if ($this->global->cache->createCache('%a%')) /* line %a% */
+		if ($this->global->cache->createCache('%a%')) /* %a% */
 		try {
 			echo '	';
-			echo LR\%a%(($this->filters->lower)($title)) /* line %a% */;
+			echo LR\%a%(($this->filters->lower)($title)) /* %a% */;
 			echo "\n";
 
-			$this->global->cache->end() /* line %a% */;
+			$this->global->cache->end() /* %a% */;
 		} catch (\Throwable $ʟ_e) {
 			$this->global->cache->rollback();
 			throw $ʟ_e;

--- a/tests/Bridges.Latte3/expected/cache.php
+++ b/tests/Bridges.Latte3/expected/cache.php
@@ -3,18 +3,18 @@
 		echo 'Noncached content
 
 ';
-		if ($this->global->cache->createCache('%a%', [$id, 'tags' => 'mytag'])) /* line %a% */
+		if ($this->global->cache->createCache('%a%', [$id, 'tags' => 'mytag'])) /* %a% */
 		try {
 			echo '
 <h1>';
-			echo LR\%a%(($this->filters->upper)($title)) /* line %a% */;
+			echo LR\%a%(($this->filters->upper)($title)) /* %a% */;
 			echo '</h1>
 
 ';
-			$this->createTemplate('include.cache.latte', ['localvar' => 11] + $this->params, 'include')->renderToContentType('html') /* line %a% */;
+			$this->createTemplate('include.cache.latte', ['localvar' => 11] + $this->params, 'include')->renderToContentType('html') /* %a% */;
 			echo "\n";
 
-			$this->global->cache->end() /* line %a% */;
+			$this->global->cache->end() /* %a% */;
 		} catch (\Throwable $ʟ_e) {
 			$this->global->cache->rollback();
 			throw $ʟ_e;

--- a/tests/Storages/FileStorage.corrupted.phpt
+++ b/tests/Storages/FileStorage.corrupted.phpt
@@ -1,0 +1,118 @@
+<?php declare(strict_types=1);
+
+/**
+ * Test: Nette\Caching\Storages\FileStorage handles corrupted cache files gracefully.
+ *
+ * Verifies that reading a corrupted cache file returns null instead of
+ * throwing unserialize errors. Covers both corrupted metadata and
+ * corrupted data payloads.
+ */
+
+use Nette\Caching\Cache;
+use Nette\Caching\Storages\FileStorage;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+$dir = getTempDir();
+$storage = new FileStorage($dir);
+$cache = new Cache($storage);
+
+
+// --- Corrupted metadata ---
+
+$cache->save('meta-test', 'hello');
+Assert::same('hello', $cache->load('meta-test'));
+
+// Find the cache file and corrupt its metadata
+$files = glob($dir . '/_*');
+Assert::truthy($files);
+
+foreach ($files as $file) {
+	if (is_file($file)) {
+		// Overwrite with a valid-looking size header but garbage meta.
+		// "000010" = meta size of 10, followed by non-serialized data.
+		file_put_contents($file, '000010not-serial');
+	}
+}
+
+// Reading corrupted meta should return null, not crash
+Assert::null($cache->load('meta-test'));
+
+
+// --- Corrupted serialized data ---
+
+// Use a fresh storage to avoid interference
+$dir2 = getTempDir() . '/data-test';
+@mkdir($dir2, 0777, true);
+$storage2 = new FileStorage($dir2);
+$cache2 = new Cache($storage2);
+
+$cache2->save('data-test', ['complex' => 'array', 'with' => [1, 2, 3]]);
+Assert::type('array', $cache2->load('data-test'));
+
+// Find the cache file
+$files2 = glob($dir2 . '/_*');
+Assert::truthy($files2);
+
+foreach ($files2 as $file) {
+	if (is_file($file)) {
+		$content = file_get_contents($file);
+		$size = (int) substr($content, 0, 6);
+		$headerAndMeta = substr($content, 0, 6 + $size);
+		// Keep valid header+meta but replace data with garbage
+		file_put_contents($file, $headerAndMeta . 'CORRUPTED-DATA-NOT-SERIALIZABLE');
+	}
+}
+
+// Reading corrupted data should not crash.
+// The result may be false (failed unserialize) but must not throw.
+Assert::noError(function () use ($cache2) {
+	$cache2->load('data-test');
+});
+
+
+// --- Truncated file ---
+
+$dir3 = getTempDir() . '/truncated-test';
+@mkdir($dir3, 0777, true);
+$storage3 = new FileStorage($dir3);
+$cache3 = new Cache($storage3);
+
+$cache3->save('trunc-test', str_repeat('x', 10000));
+Assert::same(str_repeat('x', 10000), $cache3->load('trunc-test'));
+
+// Truncate the file mid-data
+$files3 = glob($dir3 . '/_*');
+foreach ($files3 as $file) {
+	if (is_file($file)) {
+		$handle = fopen($file, 'r+b');
+		ftruncate($handle, 50); // keep header + partial meta
+		fclose($handle);
+	}
+}
+
+// Should return null, not crash
+Assert::null($cache3->load('trunc-test'));
+
+
+// --- File with all zero bytes ---
+
+$dir4 = getTempDir() . '/zeros-test';
+@mkdir($dir4, 0777, true);
+$storage4 = new FileStorage($dir4);
+$cache4 = new Cache($storage4);
+
+$cache4->save('zero-test', 'data');
+
+$files4 = glob($dir4 . '/_*');
+foreach ($files4 as $file) {
+	if (is_file($file)) {
+		file_put_contents($file, str_repeat("\x00", 100));
+	}
+}
+
+// All-zero header = size 0, should return null
+Assert::null($cache4->load('zero-test'));

--- a/tests/Storages/FileStorage.gc-foreign-files.phpt
+++ b/tests/Storages/FileStorage.gc-foreign-files.phpt
@@ -1,0 +1,88 @@
+<?php declare(strict_types=1);
+
+/**
+ * Test: Nette\Caching\Storages\FileStorage clean() skips non-cache files.
+ *
+ * Regression test for GH#45: FileStorage GC crashes with "unserialize(): Error at offset"
+ * when non-cache files (e.g. Latte lock files) matching the _* pattern exist
+ * in the cache directory.
+ */
+
+use Nette\Caching\Cache;
+use Nette\Caching\Storages\FileStorage;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+$dir = getTempDir();
+$storage = new FileStorage($dir);
+$cache = new Cache($storage);
+
+
+// Write valid cache entries
+$cache->save('key1', 'value1');
+$cache->save('key2', 'value2');
+
+Assert::same('value1', $cache->load('key1'));
+Assert::same('value2', $cache->load('key2'));
+
+
+// Create foreign files that match the _* pattern used by GC.
+// These simulate Latte lock files and other non-cache files that may
+// coexist in the same temp directory tree.
+
+// Case 1: Content starting with digits — triggers (int) cast to non-zero size
+// in readMetaAndLock(), then garbage gets passed to unserialize().
+// This is the exact scenario from GH#45 diagnosis by @martinbohmcz:
+// PHP 8 interprets "0942e7" as float 942e7, (int) cast = 9420000.
+file_put_contents($dir . '/_includes-template.php.lock', '0942e7deadbeef');
+
+// Case 2: Binary content
+file_put_contents($dir . '/_session.lock', "\xff\xfe\x00\x01\x80\x90binary");
+
+// Case 3: Empty file
+file_put_contents($dir . '/_empty.lock', '');
+
+// Case 4: File with zero-like header (6 bytes of zeros = size 0, skip path)
+file_put_contents($dir . '/_zero-header.tmp', '000000some-data');
+
+// Case 5: File with valid-looking size but garbage meta
+file_put_contents($dir . '/_fake-meta.dat', '000010not-a-serialized-array');
+
+// Case 6: File in a subdirectory matching _* pattern
+@mkdir($dir . '/_subdir', 0777, true);
+file_put_contents($dir . '/_subdir/_nested.lock', 'nested-lock-data');
+
+
+// GC (collector mode) must not crash on foreign files
+Assert::noError(function () use ($storage) {
+	$storage->clean([]);
+});
+
+
+// Valid cache entries must still be readable
+Assert::same('value1', $cache->load('key1'));
+Assert::same('value2', $cache->load('key2'));
+
+
+// Foreign files must be untouched (GC should skip, not delete them)
+Assert::true(file_exists($dir . '/_includes-template.php.lock'));
+Assert::true(file_exists($dir . '/_session.lock'));
+Assert::true(file_exists($dir . '/_empty.lock'));
+Assert::true(file_exists($dir . '/_zero-header.tmp'));
+Assert::true(file_exists($dir . '/_fake-meta.dat'));
+Assert::true(file_exists($dir . '/_subdir/_nested.lock'));
+
+
+// Cache::All mode deletes all _* files including foreign ones — expected behavior
+$storage->clean([Cache::All => true]);
+
+Assert::null($cache->load('key1'));
+Assert::null($cache->load('key2'));
+Assert::false(file_exists($dir . '/_includes-template.php.lock'));
+Assert::false(file_exists($dir . '/_session.lock'));
+Assert::false(file_exists($dir . '/_empty.lock'));
+Assert::false(file_exists($dir . '/_zero-header.tmp'));
+Assert::false(file_exists($dir . '/_fake-meta.dat'));

--- a/tests/Storages/FileStorage.sliding.bulk.phpt
+++ b/tests/Storages/FileStorage.sliding.bulk.phpt
@@ -1,12 +1,11 @@
 <?php declare(strict_types=1);
 
 /**
- * Test: Nette\Caching\Storages\SQLiteStorage expiration test.
- * @phpExtension pdo_sqlite
+ * Test: Nette\Caching\Storages\FileStorage sliding expiration test.
  */
 
 use Nette\Caching\Cache;
-use Nette\Caching\Storages\SQLiteStorage;
+use Nette\Caching\Storages\FileStorage;
 use Tester\Assert;
 
 
@@ -16,7 +15,7 @@ require __DIR__ . '/../bootstrap.php';
 $key = 'nette';
 $value = 'rulez';
 
-$cache = new Cache(new SQLiteStorage(':memory:'));
+$cache = new Cache(new FileStorage(getTempDir()));
 
 
 // Writing cache...
@@ -29,11 +28,13 @@ $cache->save($key, $value, [
 for ($i = 0; $i < 5; $i++) {
 	// Sleeping 1 second
 	sleep(1);
+	clearstatcache();
 
-	Assert::truthy($cache->load($key));
+	Assert::truthy($cache->bulkLoad([$key])[$key]);
 }
 
 // Sleeping few seconds...
 sleep(5);
+clearstatcache();
 
-Assert::null($cache->load($key));
+Assert::null($cache->bulkLoad([$key])[$key]);

--- a/tests/Storages/FileStorage.stress.phpt
+++ b/tests/Storages/FileStorage.stress.phpt
@@ -31,13 +31,19 @@ function checkStr($s)
 define('COUNT_FILES', 3);
 
 
-$storage = new FileStorage(getTempDir());
+$dir = getTempDir();
+$storage = new FileStorage($dir);
 
 
 // clear playground
 for ($i = 0; $i <= COUNT_FILES; $i++) {
 	$storage->write((string) $i, randomStr(), []);
 }
+
+// GH#45: place foreign files in the cache directory to verify they don't
+// interfere with normal cache operations or cause unserialize errors during GC
+file_put_contents($dir . '/_foreign.lock', '0942e7deadbeef');
+file_put_contents($dir . '/_session.tmp', "\xff\xfe\x00\x01binary");
 
 // test loop
 $hits = ['ok' => 0, 'notfound' => 0, 'error' => 0, 'cantwrite' => 0, 'cantdelete' => 0];

--- a/tests/Storages/Memcached.sliding.bulk.phpt
+++ b/tests/Storages/Memcached.sliding.bulk.phpt
@@ -36,10 +36,10 @@ for ($i = 0; $i < 5; $i++) {
 	// Sleeping 1 second
 	sleep(1);
 
-	Assert::truthy($cache->load($key));
+	Assert::truthy($cache->bulkLoad([$key])[$key]);
 }
 
 // Sleeping few seconds...
 sleep(5);
 
-Assert::null($cache->load($key));
+Assert::null($cache->bulkLoad([$key])[$key]);

--- a/tests/Storages/SQLiteStorage.sliding.bulk.phpt
+++ b/tests/Storages/SQLiteStorage.sliding.bulk.phpt
@@ -30,10 +30,10 @@ for ($i = 0; $i < 5; $i++) {
 	// Sleeping 1 second
 	sleep(1);
 
-	Assert::truthy($cache->load($key));
+	Assert::truthy($cache->bulkLoad([$key])[$key]);
 }
 
 // Sleeping few seconds...
 sleep(5);
 
-Assert::null($cache->load($key));
+Assert::null($cache->bulkLoad([$key])[$key]);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -11,6 +11,7 @@ if (@!include __DIR__ . '/../vendor/autoload.php') {
 
 // configure environment
 Tester\Environment::setup();
+Tester\Environment::setupFunctions();
 date_default_timezone_set('Europe/Prague');
 
 
@@ -32,10 +33,4 @@ function getTempDir(): string
 	}
 
 	return $dir;
-}
-
-
-function test(string $title, Closure $function): void
-{
-	$function();
 }

--- a/tests/types/TypesTest.phpt
+++ b/tests/types/TypesTest.phpt
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+require __DIR__ . '/../bootstrap.php';
+
+use Nette\PHPStan\Tester\TypeAssert;
+
+TypeAssert::assertTypes(__DIR__ . '/caching-types.php');

--- a/tests/types/caching-types.php
+++ b/tests/types/caching-types.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+
+/**
+ * PHPStan type tests for Caching.
+ */
+
+use Nette\Caching\Cache;
+use function PHPStan\Testing\assertType;
+
+
+function testCacheLoad(Cache $cache): void
+{
+	$value = $cache->load('key', function (&$dependencies) {
+		assertType('mixed', $dependencies);
+		return 'value';
+	});
+	assertType('mixed', $value);
+}
+
+
+/** @param list<string> $keys */
+function testCacheBulkLoad(Cache $cache, array $keys): void
+{
+	$values = $cache->bulkLoad($keys, function ($key, &$dependencies) {
+		assertType('string', $key);
+		assertType('mixed', $dependencies);
+		return 'value';
+	});
+	assertType('array<string, mixed>', $values);
+}
+
+
+/** @param list<int> $keys */
+function testCacheBulkLoadIntKeys(Cache $cache, array $keys): void
+{
+	$values = $cache->bulkLoad($keys, function ($key, &$dependencies) {
+		assertType('int', $key);
+		return 'value';
+	});
+	assertType('array<int, mixed>', $values);
+}


### PR DESCRIPTION
## Summary

Fix `clean()` crashing with `unserialize(): Error at offset` when non-cache files (e.g. Latte lock files) exist in the cache directory with names matching the `_*` pattern.

## Root cause

`FileStorage::readMetaAndLock()` calls `unserialize()` on arbitrary file contents without error handling. The `clean()` method uses `Finder::find('_*')` to scan the cache directory, which matches **all** underscore-prefixed files — not just cache entries. When a non-cache file like `_template.php.lock` with content `0942e7` is encountered:

1. The 6-byte header read produces `(int) "0942e7"` → non-zero size
2. `stream_get_contents()` reads garbage bytes
3. `unserialize()` fails with "Error at offset X of Y bytes"

This was diagnosed by @martinbohmcz in https://github.com/nette/caching/issues/45#issuecomment-2688236792 — after renaming the directory to avoid the underscore prefix, the errors stopped.

## Solution

**`readMetaAndLock()`** — Replace unguarded `unserialize()` + `assert(is_array())` with `@unserialize()` + `is_array()` runtime validation. Non-cache files now return `null` instead of crashing. The `@` error suppression is consistent with other I/O operations in the same method (e.g. `@fopen` on line 303).

**`readData()`** — Add defensive `@unserialize()` for corrupted serialized data payloads (e.g. from truncated writes after process crashes).

## What this does NOT change

The write path and locking model remain untouched. The current header-last write strategy (null bytes → data → seek → header) is a deliberate design that uses the header as a commit marker. True atomic writes via temp file + rename would require rethinking the stampede prevention locking model (currently file-handle based), which is a separate concern.

## Changes by file

- `src/Caching/Storages/FileStorage.php` — defensive unserialize in `readMetaAndLock()` and `readData()`
- `tests/Storages/FileStorage.gc-foreign-files.phpt` — **new**: regression test for GC with foreign files (6 scenarios: digit-prefixed content, binary, empty, zero-header, fake meta, nested subdirectory)
- `tests/Storages/FileStorage.corrupted.phpt` — **new**: graceful handling of corrupted metadata, corrupted data payload, truncated files, all-zero files
- `tests/Storages/FileStorage.stress.phpt` — enhanced: foreign files placed in cache dir during 1000-iteration stress test

## Testing

- [x] All 62 existing tests pass (8 skipped — Memcached extension)
- [x] 2 new test files covering the exact scenarios from the bug report
- [x] Stress test enhanced with foreign files
- [x] PHPStan analysis clean
- [x] No debug artifacts in diff

## Related issue

Closes #45